### PR TITLE
Implementation of OCMSaveObjects

### DIFF
--- a/Source/OCMArg.h
+++ b/Source/OCMArg.h
@@ -22,6 +22,7 @@
 // manipulating arguments
 
 + (id *)setTo:(id)value;
++ (id)saveObjects:(NSMutableArray*)array;
 
 // internal use only
 

--- a/Source/OCMArg.m
+++ b/Source/OCMArg.m
@@ -6,6 +6,7 @@
 #import <OCMock/OCMArg.h>
 #import <OCMock/OCMConstraint.h>
 #import "OCMPassByRefSetter.h"
+#import "OCMSaveObjects.h"
 #import "OCMConstraint.h"
 
 @implementation OCMArg
@@ -54,6 +55,10 @@
 + (id *)setTo:(id)value
 {
 	return (id *)[[[OCMPassByRefSetter alloc] initWithValue:value] autorelease];
+}
+
++ (id)saveObjects:(NSMutableArray *)array {
+  return [[[OCMSaveObjects alloc] initWithArray:array] autorelease];
 }
 
 + (id)resolveSpecialValues:(NSValue *)value

--- a/Source/OCMSaveObjects.h
+++ b/Source/OCMSaveObjects.h
@@ -1,0 +1,12 @@
+#import <Foundation/Foundation.h>
+
+@interface OCMSaveObjects : NSObject 
+{
+  NSMutableArray *array;
+}
+
+- (id)initWithArray:(NSMutableArray*)aArray;
+
+- (void)setObject:(id)aObject;
+
+@end

--- a/Source/OCMSaveObjects.m
+++ b/Source/OCMSaveObjects.m
@@ -1,0 +1,30 @@
+#import "OCMSaveObjects.h"
+
+@implementation OCMSaveObjects
+
+- (id)initWithArray:(NSMutableArray*)aArray
+{
+	[super init];
+  array = [aArray retain];
+	return self;
+}
+
+- (void)dealloc
+{
+  [array release];
+	[super dealloc];
+}
+
+- (void)setObject:(id)aObject
+{
+  if (aObject == nil)
+  {
+    [array addObject:[NSNull null]];
+  }
+  else
+  {
+    [array addObject:aObject];
+  }
+}
+
+@end

--- a/Source/OCMock.xcodeproj/project.pbxproj
+++ b/Source/OCMock.xcodeproj/project.pbxproj
@@ -165,6 +165,12 @@
 		03F1FE8B10353A5F00E4962C /* NSMethodSignature+OCMAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 03F1FE8810353A5F00E4962C /* NSMethodSignature+OCMAdditions.m */; };
 		8DC2EF510486A6940098B216 /* OCMock_Prefix.pch in Headers */ = {isa = PBXBuildFile; fileRef = 32DBCF5E0370ADEE00C91783 /* OCMock_Prefix.pch */; };
 		9F35D3DC0D349E7E00C05E52 /* OCMock.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8DC2EF5B0486A6940098B216 /* OCMock.framework */; };
+		AD47FB3F129445E80029D8C6 /* OCMSaveObjects.h in Headers */ = {isa = PBXBuildFile; fileRef = AD47FB3D129445E80029D8C6 /* OCMSaveObjects.h */; };
+		AD47FB40129445E80029D8C6 /* OCMSaveObjects.m in Sources */ = {isa = PBXBuildFile; fileRef = AD47FB3E129445E80029D8C6 /* OCMSaveObjects.m */; };
+		AD47FB41129445E80029D8C6 /* OCMSaveObjects.h in Headers */ = {isa = PBXBuildFile; fileRef = AD47FB3D129445E80029D8C6 /* OCMSaveObjects.h */; };
+		AD47FB42129445E80029D8C6 /* OCMSaveObjects.m in Sources */ = {isa = PBXBuildFile; fileRef = AD47FB3E129445E80029D8C6 /* OCMSaveObjects.m */; };
+		AD47FB44129445E80029D8C6 /* OCMSaveObjects.h in Headers */ = {isa = PBXBuildFile; fileRef = AD47FB3D129445E80029D8C6 /* OCMSaveObjects.h */; };
+		AD47FB45129445E80029D8C6 /* OCMSaveObjects.m in Sources */ = {isa = PBXBuildFile; fileRef = AD47FB3E129445E80029D8C6 /* OCMSaveObjects.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -259,6 +265,8 @@
 		32DBCF5E0370ADEE00C91783 /* OCMock_Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OCMock_Prefix.pch; sourceTree = "<group>"; };
 		8DC2EF5A0486A6940098B216 /* Info.plist */ = {isa = PBXFileReference; explicitFileType = text.plist.xml; fileEncoding = 4; path = Info.plist; sourceTree = "<group>"; };
 		8DC2EF5B0486A6940098B216 /* OCMock.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = OCMock.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		AD47FB3D129445E80029D8C6 /* OCMSaveObjects.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OCMSaveObjects.h; sourceTree = "<group>"; };
+		AD47FB3E129445E80029D8C6 /* OCMSaveObjects.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OCMSaveObjects.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -360,6 +368,8 @@
 		037C134A0FCC47B500257C8C /* Argument Handling */ = {
 			isa = PBXGroup;
 			children = (
+				AD47FB3D129445E80029D8C6 /* OCMSaveObjects.h */,
+				AD47FB3E129445E80029D8C6 /* OCMSaveObjects.m */,
 				0378606B0F6A32F800A4D9A0 /* OCMArg.h */,
 				0378606C0F6A32F800A4D9A0 /* OCMArg.m */,
 				0343133B0CCA771800A2E080 /* OCMConstraint.h */,
@@ -529,6 +539,7 @@
 				03E41DBA11F5A86A00147791 /* OCMBoxedReturnValueProvider.h in Headers */,
 				03E41DBC11F5A86C00147791 /* OCMReturnValueProvider.h in Headers */,
 				0340A5BB121E973000158484 /* OCMRealObjectForwarder.h in Headers */,
+				AD47FB41129445E80029D8C6 /* OCMSaveObjects.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -558,6 +569,7 @@
 				03DAC00411FEB771007AF17B /* OCMBoxedReturnValueProvider.h in Headers */,
 				03DAC00511FEB771007AF17B /* OCMReturnValueProvider.h in Headers */,
 				0340A5BD121E973000158484 /* OCMRealObjectForwarder.h in Headers */,
+				AD47FB3F129445E80029D8C6 /* OCMSaveObjects.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -588,6 +600,7 @@
 				03F1FE8A10353A5F00E4962C /* NSMethodSignature+OCMAdditions.h in Headers */,
 				03CFB08C117B308C00935C1E /* OCMBlockCaller.h in Headers */,
 				0340A5BF121E973000158484 /* OCMRealObjectForwarder.h in Headers */,
+				AD47FB44129445E80029D8C6 /* OCMSaveObjects.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -797,6 +810,7 @@
 				03E41DB911F5A86900147791 /* OCMBoxedReturnValueProvider.m in Sources */,
 				03E41DBB11F5A86B00147791 /* OCMReturnValueProvider.m in Sources */,
 				0340A5BC121E973000158484 /* OCMRealObjectForwarder.m in Sources */,
+				AD47FB42129445E80029D8C6 /* OCMSaveObjects.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -838,6 +852,7 @@
 				03DAC01911FEB771007AF17B /* OCMBoxedReturnValueProvider.m in Sources */,
 				03DAC01A11FEB771007AF17B /* OCMReturnValueProvider.m in Sources */,
 				0340A5BE121E973000158484 /* OCMRealObjectForwarder.m in Sources */,
+				AD47FB40129445E80029D8C6 /* OCMSaveObjects.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -866,6 +881,7 @@
 				03F1FE8B10353A5F00E4962C /* NSMethodSignature+OCMAdditions.m in Sources */,
 				03CFB08D117B308C00935C1E /* OCMBlockCaller.m in Sources */,
 				0340A5C0121E973000158484 /* OCMRealObjectForwarder.m in Sources */,
+				AD47FB45129445E80029D8C6 /* OCMSaveObjects.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Source/OCMockObjectTests.m
+++ b/Source/OCMockObjectTests.m
@@ -431,6 +431,29 @@ static NSString *TestNotification = @"TestNotification";
 	STAssertEqualObjects(expectedArray, actualArray, @"The two array objects should be equal");
 }
 
+- (void)testSaveObjects
+{
+  NSMutableArray *array = [NSMutableArray array];
+  [[[mock stub] andReturn:nil] initWithContentsOfURL:[OCMArg saveObjects:array] usedEncoding:nil error:NULL];
+  
+  NSURL *url1 = [NSURL URLWithString:@"http://example1.com/"];
+  NSURL *url2 = [NSURL URLWithString:@"http://example2.com/"];
+  [mock initWithContentsOfURL:url1 usedEncoding:nil error:NULL];
+  [mock initWithContentsOfURL:url2 usedEncoding:nil error:NULL];
+  
+  STAssertEqualObjects(url1, [array objectAtIndex:0], @"Should equal url1");
+  STAssertEqualObjects(url2, [array objectAtIndex:1], @"Should equal url2");
+}
+
+- (void)testSaveObjectsNil
+{
+  NSMutableArray *array = [NSMutableArray array];
+  [[[mock stub] andReturn:nil] initWithContentsOfURL:[OCMArg saveObjects:array] usedEncoding:nil error:NULL];
+  
+  [mock initWithContentsOfURL:nil usedEncoding:nil error:NULL];
+  
+  STAssertEqualObjects([NSNull null], [array objectAtIndex:0], @"Should be NSNull");
+}
 
 // --------------------------------------------------------------------------------------
 //	accepting expected methods

--- a/Source/OCMockRecorder.m
+++ b/Source/OCMockRecorder.m
@@ -8,6 +8,7 @@
 #import <OCMock/OCMArg.h>
 #import <OCMock/OCMConstraint.h>
 #import "OCMPassByRefSetter.h"
+#import "OCMSaveObjects.h"
 #import "OCMReturnValueProvider.h"
 #import "OCMBoxedReturnValueProvider.h"
 #import "OCMExceptionReturnValueProvider.h"
@@ -162,6 +163,10 @@
 		{
 			// side effect but easier to do here than in handleInvocation
 			*(id *)[passedArg pointerValue] = [(OCMPassByRefSetter *)recordedArg value];
+		}
+		else if([recordedArg isKindOfClass:[OCMSaveObjects class]])
+		{
+			[recordedArg setObject:passedArg];
 		}
 		else if([recordedArg conformsToProtocol:objc_getProtocol("HCMatcher")])
 		{


### PR DESCRIPTION
One feature I'd like to have in OCMock is something equivalent to GoogleMock's "SaveArg<N>(pointer)" (you can see a description of this at http://code.google.com/p/googlemock/wiki/CheatSheet#Side_Effects). In the pull request, I've implemented an OCMSaveObject argument handler that sets pointer of the supplied ptr to a pointer to the argument.

This is useful if you want to do additional verification of the object beyond what can be done by a matcher.
