### PR TITLE
'cString' is deprecated, use UTF8String instead

### DIFF
--- a/Source/OCMock/OCPartialMockObject.m
+++ b/Source/OCMock/OCPartialMockObject.m
@@ -91,7 +91,7 @@ static NSMutableDictionary *mockTable;
 {
 	Class realClass = [anObject class];
 	double timestamp = [NSDate timeIntervalSinceReferenceDate];
-	const char *className = [[NSString stringWithFormat:@"%@-%p-%f", realClass, anObject, timestamp] cString]; 
+	const char *className = [[NSString stringWithFormat:@"%@-%p-%f", realClass, anObject, timestamp] UTF8String];
 	Class subclass = objc_allocateClassPair(realClass, className, 0);
 	objc_registerClassPair(subclass);
 	object_setClass(anObject, subclass);


### PR DESCRIPTION
This stops a warning currently showing up on clang version 3.1 (trunk 148039). This would prevent the warning from appearing when compiling the Chromium codebase.

See this issue for the tracking point: http://code.google.com/p/chromium/issues/detail?id=110803
