### PR TITLE
Fix warnings appearing in clang version 3.1 (trunk 148911)

### DIFF
--- a/Source/OCMock/NSInvocation+OCMAdditions.m
+++ b/Source/OCMock/NSInvocation+OCMAdditions.m
@@ -257,7 +257,7 @@
 	long longValue;
 	
 	[self getArgument:&longValue atIndex:anInt];
-	return [NSString stringWithFormat:@"%d", longValue];
+	return [NSString stringWithFormat:@"%ld", longValue];
 }
 
 - (NSString *)unsignedLongDescriptionAtIndex:(int)anInt
@@ -265,7 +265,7 @@
 	unsigned long longValue;
 	
 	[self getArgument:&longValue atIndex:anInt];
-	return [NSString stringWithFormat:@"%u", longValue];
+	return [NSString stringWithFormat:@"%lu", longValue];
 }
 
 - (NSString *)longLongDescriptionAtIndex:(int)anInt
@@ -323,7 +323,7 @@
 	memset(buffer, 0x0, 128);
 	
 	[self getArgument:&buffer atIndex:anInt];
-	return [NSString stringWithFormat:@"\"%S\"", buffer];
+	return [NSString stringWithFormat:@"\"%s\"", buffer];
 }
 
 - (NSString *)selectorDescriptionAtIndex:(int)anInt

--- a/Source/OCMock/OCMArg.m
+++ b/Source/OCMock/OCMArg.m
@@ -64,7 +64,7 @@
 		void *pointer = [value pointerValue];
 		if(pointer == (void *)0x01234567)
 			return [OCMArg any];
-		if((pointer != NULL) && (((id)pointer)->isa == [OCMPassByRefSetter class]))
+		if((pointer != NULL) && ([(id)pointer isKindOfClass:[OCMPassByRefSetter class]]))
 			return (id)pointer;
 	}
 	return value;

--- a/Source/OCMock/OCProtocolMockObject.m
+++ b/Source/OCMock/OCProtocolMockObject.m
@@ -21,7 +21,7 @@
 
 - (NSString *)description
 {
-	return [NSString stringWithFormat:@"OCMockObject[%s]", [mockedProtocol name]];
+	return [NSString stringWithFormat:@"OCMockObject[%@]", [mockedProtocol name]];
 }
 
 


### PR DESCRIPTION
This commit is related to a bug on the Chromium project, which can be
found here: http://code.google.com/p/chromium/issues/detail?id=113894
- Fixes format warnings when using stringWithFormat:
- Replace objective-c's is deprecated with isKindOfClass:
