### PR TITLE
Let OCMBlockConstraint copy the block passed into initializer to avoid problems with stack allocated blocks

### DIFF
--- a/Source/OCMock/OCMConstraint.m
+++ b/Source/OCMock/OCMConstraint.m
@@ -122,8 +122,13 @@
 - (id)initWithConstraintBlock:(BOOL (^)(id))aBlock;
 {
 	self = [super init];
-	block = aBlock;
+	block = [aBlock copy];
 	return self;
+}
+
+- (void)dealloc {
+    [block release];
+    [super dealloc];
 }
 
 - (BOOL)evaluate:(id)value 


### PR DESCRIPTION
Nicer if the client code doesn't have to bother about copying any stack allocated block if it would go out of scope before checked against.

I.e if you have a helper method setting up the expectations using constraint blocks, in which the original checker-block is created, the block is likely to be out of scope when the constraint is checked against.
