### PR TITLE
"Property chaining" functionality

### DIFF
--- a/Source/OCMock.xcodeproj/project.pbxproj
+++ b/Source/OCMock.xcodeproj/project.pbxproj
@@ -121,6 +121,11 @@
 		03E6F05F152FA8E20079EAF7 /* OCClassMockRecorder.h in Headers */ = {isa = PBXBuildFile; fileRef = 03E6F05C152FA8E20079EAF7 /* OCClassMockRecorder.h */; };
 		03E6F060152FA8E20079EAF7 /* OCClassMockRecorder.m in Sources */ = {isa = PBXBuildFile; fileRef = 03E6F05D152FA8E20079EAF7 /* OCClassMockRecorder.m */; };
 		03E6F061152FA8E20079EAF7 /* OCClassMockRecorder.m in Sources */ = {isa = PBXBuildFile; fileRef = 03E6F05D152FA8E20079EAF7 /* OCClassMockRecorder.m */; };
+		496731151612017700CC553A /* OCChainTampolineProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = 496731131612017700CC553A /* OCChainTampolineProxy.h */; };
+		496731161612017700CC553A /* OCChainTampolineProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = 496731131612017700CC553A /* OCChainTampolineProxy.h */; };
+		496731171612017700CC553A /* OCChainTampolineProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 496731141612017700CC553A /* OCChainTampolineProxy.m */; };
+		496731191612017700CC553A /* OCChainTampolineProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 496731141612017700CC553A /* OCChainTampolineProxy.m */; };
+		4967311D1612030100CC553A /* OCChainTampolineProxyTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4967311C1612030100CC553A /* OCChainTampolineProxyTests.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -208,6 +213,10 @@
 		03E6F057152FA60B0079EAF7 /* OCMockClassObject.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OCMockClassObject.m; sourceTree = "<group>"; };
 		03E6F05C152FA8E20079EAF7 /* OCClassMockRecorder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OCClassMockRecorder.h; sourceTree = "<group>"; };
 		03E6F05D152FA8E20079EAF7 /* OCClassMockRecorder.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OCClassMockRecorder.m; sourceTree = "<group>"; };
+		496731131612017700CC553A /* OCChainTampolineProxy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OCChainTampolineProxy.h; sourceTree = "<group>"; };
+		496731141612017700CC553A /* OCChainTampolineProxy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OCChainTampolineProxy.m; sourceTree = "<group>"; };
+		4967311B1612030100CC553A /* OCChainTampolineProxyTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OCChainTampolineProxyTests.h; sourceTree = "<group>"; };
+		4967311C1612030100CC553A /* OCChainTampolineProxyTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OCChainTampolineProxyTests.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -314,6 +323,8 @@
 				03B316291463350E0052CD09 /* OCObserverMockObjectTests.m */,
 				03B3161E1463350E0052CD09 /* NSInvocationOCMAdditionsTests.h */,
 				03B3161F1463350E0052CD09 /* NSInvocationOCMAdditionsTests.m */,
+				4967311B1612030100CC553A /* OCChainTampolineProxyTests.h */,
+				4967311C1612030100CC553A /* OCChainTampolineProxyTests.m */,
 				030EF0C814632FD000B04273 /* Supporting Files */,
 				030EF0AA14632FD000B04273 /* Frameworks */,
 			);
@@ -406,6 +417,8 @@
 				03B3159A146333BF0052CD09 /* OCMNotificationPoster.m */,
 				03B315A5146333BF0052CD09 /* OCMReturnValueProvider.h */,
 				03B315A6146333BF0052CD09 /* OCMReturnValueProvider.m */,
+				496731131612017700CC553A /* OCChainTampolineProxy.h */,
+				496731141612017700CC553A /* OCChainTampolineProxy.m */,
 			);
 			name = "Invocation Handler";
 			sourceTree = "<group>";
@@ -497,6 +510,7 @@
 				03B31613146333C00052CD09 /* OCProtocolMockObject.h in Headers */,
 				03E6F058152FA60B0079EAF7 /* OCMockClassObject.h in Headers */,
 				03E6F05E152FA8E20079EAF7 /* OCClassMockRecorder.h in Headers */,
+				496731151612017700CC553A /* OCChainTampolineProxy.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -534,6 +548,7 @@
 				03B316441463350E0052CD09 /* OCObserverMockObjectTests.h in Headers */,
 				03E6F059152FA60B0079EAF7 /* OCMockClassObject.h in Headers */,
 				03E6F05F152FA8E20079EAF7 /* OCClassMockRecorder.h in Headers */,
+				496731161612017700CC553A /* OCChainTampolineProxy.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -699,6 +714,7 @@
 				03B31615146333C00052CD09 /* OCProtocolMockObject.m in Sources */,
 				03E6F05A152FA60B0079EAF7 /* OCMockClassObject.m in Sources */,
 				03E6F060152FA8E20079EAF7 /* OCClassMockRecorder.m in Sources */,
+				496731171612017700CC553A /* OCChainTampolineProxy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -712,6 +728,7 @@
 				03B3163C1463350E0052CD09 /* OCMockObjectTests.m in Sources */,
 				03B316411463350E0052CD09 /* OCMockRecorderTests.m in Sources */,
 				03B316461463350E0052CD09 /* OCObserverMockObjectTests.m in Sources */,
+				4967311D1612030100CC553A /* OCChainTampolineProxyTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -742,6 +759,7 @@
 				03B31617146333C00052CD09 /* OCProtocolMockObject.m in Sources */,
 				03E6F05B152FA60B0079EAF7 /* OCMockClassObject.m in Sources */,
 				03E6F061152FA8E20079EAF7 /* OCClassMockRecorder.m in Sources */,
+				496731191612017700CC553A /* OCChainTampolineProxy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Source/OCMock/OCChainTampolineProxy.h
+++ b/Source/OCMock/OCChainTampolineProxy.h
@@ -1,0 +1,28 @@
+//
+//  OCChainTampolineProxy.h
+//  OCMock
+//
+//  Created by jc on 25/09/2012.
+//  Copyright (c) 2012 Mulle Kybernetik. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface OCChainTampolineProxy : NSProxy
+
++ (OCChainTampolineProxy*) placeholderReturningObject:(id) object
+                                               forSelector:(SEL)sel;
++ (OCChainTampolineProxy*) placeholderReturningObject:(id) object
+                                          forSelectorNamed:(NSString*)selName;
+
+- (id) init;
+- (id) initWithObject:(id) object forSelector:(SEL) sel;
+- (id) initWithObject:(id) object forSelectorNamed:(NSString*) selName;
+
+- (void) setObject:(id) object forSelector:(SEL) sel;
+- (void) setObject:(id) object forSelectorNamed:(NSString*) selName;
+
+- (id) objectForSelector:(SEL) sel;
+- (id) objectForSelectorNamed:(NSString*) sel;
+
+@end

--- a/Source/OCMock/OCChainTampolineProxy.m
+++ b/Source/OCMock/OCChainTampolineProxy.m
@@ -1,0 +1,99 @@
+//
+//  OCChainTampolineProxy.m
+//  OCMock
+//
+//  Created by jc on 25/09/2012.
+//  Copyright (c) 2012 Mulle Kybernetik. All rights reserved.
+//
+
+#import <OCMock/OCChainTampolineProxy.h>
+
+@interface OCChainTampolineProxy ()
+@property (strong) NSMutableDictionary *dictionary;
+@end
+
+@implementation OCChainTampolineProxy
+@synthesize dictionary=_dictionary;
+
++ (OCChainTampolineProxy*) placeholderReturningObject:(id) object
+                                               forSelector:(SEL)sel
+{
+    return [self placeholderReturningObject:object forSelectorNamed:NSStringFromSelector(sel)];
+}
+
++ (OCChainTampolineProxy*) placeholderReturningObject:(id) object
+                                          forSelectorNamed:(NSString*)selName
+{
+    return [[OCChainTampolineProxy alloc] initWithObject:object forSelectorNamed:selName];
+}
+
+- (id) initWithObject:(id) object forSelector:(SEL) sel
+{
+    return [self initWithObject:object forSelectorNamed:NSStringFromSelector(sel)];
+}
+
+- (id) initWithObject:(id) object forSelectorNamed:(NSString*) selName
+{
+    if ((self = [self init])) {
+        [self setObject:object forSelectorNamed:selName];
+    }
+    return self;
+}
+
+- (id) init
+{
+    _dictionary = [[NSMutableDictionary alloc] init];
+    return self;
+}
+
+- (void)dealloc
+{
+    [_dictionary release];
+    [super dealloc];
+}
+
+- (void) setObject:(id) object forSelector:(SEL) sel
+{
+    [self setObject:object forSelectorNamed:NSStringFromSelector(sel)];
+}
+
+- (void) setObject:(id) object forSelectorNamed:(NSString*) selName
+{
+    // should not already have an object to return for this selector
+    NSParameterAssert(![self.dictionary objectForKey:selName]);
+    [self.dictionary setValue:object forKey:selName];
+}
+
+- (id) objectForSelector:(SEL) sel
+{
+    return [self objectForSelectorNamed:NSStringFromSelector(sel)];
+}
+
+- (id) objectForSelectorNamed:(NSString*) sel
+{
+    id ret = [self.dictionary objectForKey:sel];
+    NSAssert1(ret, @"No object for selector named %@", sel);
+    return ret;
+}
+
+- (NSString*) description
+{
+    return [NSString stringWithFormat:@"%@, %@", NSStringFromClass(self.class), self.dictionary];
+}
+
+#pragma mark Forwarding
+
+- (NSMethodSignature*) methodSignatureForSelector:(SEL)sel
+{
+    NSAssert1([self.dictionary objectForKey:NSStringFromSelector(sel)],
+              @"No object registered for selector %@", NSStringFromSelector(sel));
+    return [NSMethodSignature signatureWithObjCTypes:"@@:"];
+}
+
+- (void) forwardInvocation:(NSInvocation *)invocation
+{
+    id obj = [self objectForSelector:invocation.selector];
+    [invocation setReturnValue:&obj];
+}
+
+@end

--- a/Source/OCMock/OCMockRecorder.h
+++ b/Source/OCMock/OCMockRecorder.h
@@ -17,6 +17,9 @@
 - (BOOL)matchesInvocation:(NSInvocation *)anInvocation;
 - (void)releaseInvocation;
 
+- (id)chainedPropertyWithPath:(NSString*)keyPath
+        terminalObjectClass:(Class) klass;
+
 - (id)andReturn:(id)anObject;
 - (id)andReturnValue:(NSValue *)aValue;
 - (id)andThrow:(NSException *)anException;

--- a/Source/OCMockTests/OCChainTampolineProxyTests.h
+++ b/Source/OCMockTests/OCChainTampolineProxyTests.h
@@ -1,0 +1,13 @@
+//
+//  OCChainTampolineProxyTests.h
+//  OCMock
+//
+//  Created by jc on 25/09/2012.
+//  Copyright (c) 2012 Mulle Kybernetik. All rights reserved.
+//
+
+#import <SenTestingKit/SenTestingKit.h>
+
+@interface OCChainTampolineProxyTests : SenTestCase
+
+@end

--- a/Source/OCMockTests/OCChainTampolineProxyTests.m
+++ b/Source/OCMockTests/OCChainTampolineProxyTests.m
@@ -1,0 +1,113 @@
+//
+//  OCChainTampolineProxyTests.m
+//  OCMock
+//
+//  Created by jc on 25/09/2012.
+//  Copyright (c) 2012 Mulle Kybernetik. All rights reserved.
+//
+
+#import "OCChainTampolineProxyTests.h"
+#import <OCMock/OCMock.h>
+#import "OCChainTampolineProxy.h"
+
+@interface OCChainTampolineProxyTests ()
+@property (strong) OCChainTampolineProxy *object;
+@property (strong) id registeredObject;
+@property (assign) SEL testSelector;
+@end
+
+@implementation OCChainTampolineProxyTests
+@synthesize object=_object;
+
+- (void) testReturnObject
+{
+    [self.object setObject:self.registeredObject
+               forSelector:self.testSelector];
+    STAssertEqualObjects(self.registeredObject,
+                         [self.object performSelector:self.testSelector],
+                         @"Object was not returned");
+}
+
+- (void) testParametersUnimportant
+{
+    SEL longSel = NSSelectorFromString(@"returnObjectForParam:andAnotherParam:andAnother");
+    [self.object setObject:self.registeredObject forSelector:longSel];
+    STAssertEqualObjects(self.registeredObject, [self.object performSelector:longSel], @"Object was not returned");
+}
+
+- (void) testUnregisteredObject
+{
+    [self.object setObject:self.registeredObject
+               forSelector:self.testSelector];
+    STAssertThrows([self.object performSelector:NSSelectorFromString(@"unregisteredSelector")],
+                   @"No object registered for this selector; should have thrown");
+}
+
+- (void) testRegisteredNone
+{
+    STAssertThrows([self.object performSelector:NSSelectorFromString(@"unregisteredSelector")],
+                   @"No objects registered; should have thrown");
+}
+
+- (void) testAlreadyRegistered
+{
+    [self.object setObject:self.registeredObject forSelector:self.testSelector];
+    STAssertThrows([self.object setObject:self.registeredObject forSelector:self.testSelector],
+                   @"Object already registered for this selector; should have thrown");
+}
+
+#pragma mark -
+#pragma mark Building chains
+
+- (void) testChainBuilding
+{
+    NSUInteger value = 10;
+    id returnedObject = nil;
+    
+    id mock = [OCMockObject mockForClass:[NSBundle class]];
+    [[[mock stub] andReturnValue:OCMOCK_VALUE(value)] chainedPropertyWithPath:@"bundleURL.foo.absoluteString.length"
+                                                        terminalObjectClass:[NSString class]];
+    id verifyMock1 = mock;
+    
+    // check chain placeholders
+    
+    // bundleURL (placeholder)
+    returnedObject = [mock bundleURL];
+    STAssertTrue([returnedObject class] == [OCChainTampolineProxy class], @"Didn't return a chain placeholder");
+    
+    // foo (placeholder)
+    STAssertNotNil([returnedObject objectForSelectorNamed:@"foo"], @"Should have object for -foo");
+    returnedObject = [returnedObject performSelector:NSSelectorFromString(@"foo")];
+    STAssertTrue([returnedObject class] == [OCChainTampolineProxy class], @"Didn't return a chain placeholder");
+    
+    // absoluteString (true mock)
+    returnedObject = [returnedObject absoluteString];
+    STAssertEqualObjects(NSStringFromClass([returnedObject class]), @"OCClassMockObject", @"Didn't return a real mock");
+    id verifyMock2 = returnedObject;
+    
+    // should now returned the stubbed value
+    NSUInteger returnedValue = [returnedObject length];
+    
+    STAssertEquals(value, returnedValue, @"Did not return eventual value");
+    
+    // check cleared up
+    [verifyMock1 verify];
+    [verifyMock2 verify];
+}
+
+
+#pragma mark -
+
+- (void) setUp
+{
+    self.object = [[OCChainTampolineProxy alloc] init];
+    self.testSelector = NSSelectorFromString(@"fooSelector");
+    self.registeredObject = [NSString string];
+}
+
+- (void) tearDown
+{
+    self.object = nil;
+}
+
+@end

--- a/Source/OCMockTests/OCMockObjectTests.m
+++ b/Source/OCMockTests/OCMockObjectTests.m
@@ -833,6 +833,19 @@ static NSString *TestNotification = @"TestNotification";
 	STAssertNoThrow([myMock aSpecialMethod:"foo"], @"Should not complain about method with type qualifiers.");
 }
 
+// --------------------------------------------------------------------------------------
+//  Property chain trampolining
+// --------------------------------------------------------------------------------------
+
+- (void)testValueWithStubbedPropertyChain
+{
+    mock = [OCMockObject mockForClass:[NSBundle class]];
+    NSUInteger length = 100;
+    [[[mock stub] andReturnValue:OCMOCK_VALUE(length)] chainedPropertyWithPath:@"bundleURL.absoluteString.length"
+                                                           terminalObjectClass:[NSString class]];
+    NSBundle *castedBundle = (NSBundle*) mock;
+    STAssertEquals(length, castedBundle.bundleURL.absoluteString.length, @"Didn't return the stubbed value");
+}
 
 // --------------------------------------------------------------------------------------
 //  some internal tests


### PR DESCRIPTION
In the past I've had a lot of trouble creating mocks for objects with deep property hierarchies:

```
object.someProperty.anotherProperty.another.value
```

At present, this means creating mocks for all the intervening objects when I'm only actually interested in stubbing the final property. With the functionality I've implemented here, all of the middle objects can be automatically generated as ```OCChainTampolineProxy``` objects, which can return a specific object (another trampoline or a *real* mock) on a particular selector.

[This test](https://github.com/itsthejb/ocmock/blob/feature/property-chaining/Source/OCMockTests/OCMockObjectTests.m#L840-848) illustrates best;

```
- (void)testValueWithStubbedPropertyChain
{
    mock = [OCMockObject mockForClass:[NSBundle class]];
    NSUInteger length = 100;
    [[[mock stub] andReturnValue:OCMOCK_VALUE(length)] chainedPropertyWithPath:@"bundleURL.absoluteString.length"
                                                           terminalObjectClass:[NSString class]];
    NSBundle *castedBundle = (NSBundle*) mock;
    STAssertEquals(length, castedBundle.bundleURL.absoluteString.length, @"Didn't return the stubbed value");
}
```

**Notes**

* Implementation is currently rather incomplete, since the chain isn't clever enough to allow tacking on to existing stubs. For example;

```
- (void)testStubAnotherPropertyOnChain
{
    mock = [OCMockObject mockForClass:[NSBundle class]];
    NSUInteger length = 100;
    [[[mock stub] andReturnValue:OCMOCK_VALUE(length)] chainedPropertyWithPath:@"bundleURL.absoluteString.length"
                                                           terminalObjectClass:[NSString class]];
    [[[mock stub] andReturn:@"foo"] chainedPropertyWithPath:@"bundleURL.absoluteString.lowercaseString"
                                                           terminalObjectClass:[NSString class]];
    
    NSBundle *castedBundle = (NSBundle*) mock;
    STAssertEquals(length, castedBundle.bundleURL.absoluteString.length, @"Didn't return the stubbed value");
    STAssertEqualObjects(@"foo", castedBundle.bundleURL.absoluteString.lowercaseString, @"Didn't return the stubbed value");
}
```

Won't work since the second call with throw away the previous chain (or worse). I think that the current implementation of the chain building currently makes this rather hard to add...

* A little hacky at the moment, since I didn't want to touch too much of the existing framework.
* ```OCChainTampolineProxy``` is quite nice, but the creation of the chain in ```-chainedPropertyWithPath:terminalObjectClass:``` isn't so elegant. It does work, at least!

I thought I should at least issue this PR now to get some feedback on the idea. I can then work on it further.