### PR TITLE
Synchronised handling of invocations

### DIFF
--- a/Source/OCMock/OCMockObject.h
+++ b/Source/OCMock/OCMockObject.h
@@ -9,10 +9,12 @@
 {
 	BOOL			isNice;
 	BOOL			expectationOrderMatters;
+  BOOL      shouldSynchroniseExpectations;
 	NSMutableArray	*recorders;
 	NSMutableArray	*expectations;
 	NSMutableArray	*rejections;
 	NSMutableArray	*exceptions;
+  dispatch_queue_t synchronisationQueue;
 }
 
 + (id)mockForClass:(Class)aClass;
@@ -28,6 +30,7 @@
 - (id)init;
 
 - (void)setExpectationOrderMatters:(BOOL)flag;
+- (void)setShouldSynchroniseExpectations:(BOOL)flag;
 
 - (id)stub;
 - (id)expect;


### PR DESCRIPTION
### Description

Simple additions to OCMockObject to perform `handleInvocation:`, `verify` and `handleUnRecordedInvocation:` to perform them in a synchronised manner.
### Protected Additions

``` objective-c
dispatch_queue_t synchronisationQueue;
```

Concurrent private queue used to synchronise concurrent invocations

``` objective-c
BOOL shouldSynchroniseExpectations
- (void)setShouldSynchroniseExpectations:(BOOL)flag;
```

Option to use synchronisation or not.
### Motivation

When attempting to mock an object which expects multiple invocations called from code executing concurrently, mutating the arrays in  `handleInvocation:` is not thread-safe. This causes race conditions in`handleInvocation:`  for example between invocations calling `[recorders objectAtIndex:i]` `[recorders removeObjectAtIndex:i]` resulting in `NSInternalInconsistencyException: index out of bounds`  or removing the wrong recorder leading to `verify` failing.
### Discussion

I couldn't find any document about coding styles/standards so I tried to follow your style.
This uses `dispatch_sync` for concurrent access and `dispatch_barrier` for serial mutation, this follows on a lock-less concurrent resource access pattern. This is probably not the nicest implementation but it does prevent the mentioned race conditions in the simplest manner, therefore you may wish to modify the code to match your preferences.

**This is a simple and crude implementation designed more as a proof of concept.**
