### PR TITLE
Added support for typedefs

### DIFF
--- a/Source/OCMock/OCMReturnValueProvider.m
+++ b/Source/OCMock/OCMReturnValueProvider.m
@@ -25,9 +25,19 @@
 - (void)handleInvocation:(NSInvocation *)anInvocation
 {
 	const char *returnType = [[anInvocation methodSignature] methodReturnTypeWithoutQualifiers];
-	if(strcmp(returnType, @encode(id)) != 0)
-		@throw [NSException exceptionWithName:NSInvalidArgumentException reason:@"Expected invocation with object return type. Did you mean to use andReturnValue: instead?" userInfo:nil];
-	[anInvocation setReturnValue:&returnValue];	
+	if(strcmp(returnType, @encode(id)) != 0) {
+        // if the returnType is a typedef to an object, it has the form ^{OriginalClass=#}
+        NSString *regexString= @"^\\^\\{(.*)=#\\}";
+        NSError *error= nil;
+        NSRegularExpression *regex= [NSRegularExpression regularExpressionWithPattern:regexString options:0 error:&error];
+        NSString *type= [NSString stringWithCString:returnType encoding:NSASCIIStringEncoding];
+        NSUInteger match= [regex numberOfMatchesInString:type options:0 range:NSMakeRange(0, type.length)];
+        if(!match) {
+            // it's no typedef to an class and no class itself
+            @throw [NSException exceptionWithName:NSInvalidArgumentException reason:@"Expected invocation with object return type. Did you mean to use andReturnValue: instead?" userInfo:nil];
+        }
+    }
+	[anInvocation setReturnValue:&returnValue];
 }
 
 @end

--- a/Source/OCMockTests/OCMockObjectTests.m
+++ b/Source/OCMockTests/OCMockObjectTests.m
@@ -10,6 +10,16 @@
 //	Helper classes and protocols for testing
 // --------------------------------------------------------------------------------------
 
+@interface InterfaceForTypedef : NSObject
+@end
+
+@implementation InterfaceForTypedef
+@end
+
+typedef InterfaceForTypedef TypedefInterface;
+typedef InterfaceForTypedef* PointerTypedefInterface;
+typedef int intTypedef;
+
 @protocol TestProtocol
 - (int)primitiveValue;
 @optional
@@ -20,6 +30,37 @@
 - (void)aSpecialMethod:(byref in void *)someArg;
 @end
 
+@protocol ProtocolWithTypedefs
+- (TypedefInterface*)typedefReturnValue1;
+- (PointerTypedefInterface)typedefReturnValue2;
+- (void)typedefParameter:(TypedefInterface*)parameter;
+- (void)typedefPointerParameter:(PointerTypedefInterface)parameter;
+@end
+
+@interface ProtocolWithTypedefsImplementation : NSObject<ProtocolWithTypedefs>
+- (TypedefInterface*)typedefReturnValue1;
+- (PointerTypedefInterface)typedefReturnValue2;
+- (void)typedefParameter:(TypedefInterface*)parameter;
+- (void)typedefPointerParameter:(PointerTypedefInterface)parameter;
+@end
+
+@implementation ProtocolWithTypedefsImplementation
+
+- (TypedefInterface*)typedefReturnValue1 {
+    return nil;
+}
+
+- (PointerTypedefInterface)typedefReturnValue2 {
+    return nil;
+}
+
+- (void)typedefParameter:(TypedefInterface*)parameter {
+}
+
+-(void)typedefPointerParameter:(PointerTypedefInterface)parameter {
+}
+
+@end
 
 @interface TestClassThatCallsSelf : NSObject
 - (NSString *)method1;
@@ -650,6 +691,23 @@ static NSString *TestNotification = @"TestNotification";
     STAssertFalse([mock respondsToSelector:@selector(fooBar)], nil);
 }
 
+- (void)testWithTypedefReturnType {
+	mock = [OCMockObject mockForProtocol:@protocol(ProtocolWithTypedefs)];
+    STAssertNoThrow([[[mock stub] andReturn:[TypedefInterface new]] typedefReturnValue1], @"Should accept a typedefed return-type");
+    STAssertNoThrow([mock typedefReturnValue1], @"bla");
+}
+
+- (void)testWithTypedefPointerReturnType {
+	mock = [OCMockObject mockForProtocol:@protocol(ProtocolWithTypedefs)];
+    STAssertNoThrow([[[mock stub] andReturn:[TypedefInterface new]] typedefReturnValue2], @"Should accept a typedefed return-type");
+    STAssertNoThrow([mock typedefReturnValue2], @"bla");
+}
+
+- (void)testWithTypedefParameter {
+	mock = [OCMockObject mockForProtocol:@protocol(ProtocolWithTypedefs)];
+    STAssertNoThrow([[mock stub] typedefParameter:nil], @"Should accept a typedefed parameter-type");
+    STAssertNoThrow([mock typedefParameter:nil], @"bla");
+}
 
 // --------------------------------------------------------------------------------------
 //	nice mocks don't complain about unknown methods


### PR DESCRIPTION
OCMock didn't work for cases in that a method has to return an object with a typedefd type - this patch will make it work
