### PR TITLE
Copy the block before saving it to our ivar

### DIFF
--- a/Source/OCMock/OCMConstraint.m
+++ b/Source/OCMock/OCMConstraint.m
@@ -131,6 +131,12 @@
 	return block(value);
 }
 
+-(void)dealloc
+{
+	[block release];
+	[super dealloc];
+}
+
 @end
 
 #endif


### PR DESCRIPTION
I was getting a "section not addressable" crash using an OCMBlockConstraint, and noticed that the block is not being copied.  Block properties should always be copied; see e.g. http://blog.refractalize.org/post/10476042560/copy-vs-retain-for-objective-c-blocks

This commit copies the block and fixes the crashes I was getting.
