### PR TITLE
Bug fix: prevent a crash in ARC managed tests.

### DIFF
--- a/Source/OCMock/OCMReturnValueProvider.m
+++ b/Source/OCMock/OCMReturnValueProvider.m
@@ -31,12 +31,14 @@
         NSError *error= nil;
         NSRegularExpression *regex= [NSRegularExpression regularExpressionWithPattern:regexString options:0 error:&error];
         NSString *type= [NSString stringWithCString:returnType encoding:NSASCIIStringEncoding];
-        NSUInteger match= [regex numberOfMatchesInString:type options:0 range:NSMakeRange(0, type.length)];
+        NSUInteger match = [regex numberOfMatchesInString:type options:0 range:NSMakeRange(0, type.length)];
         if(!match) {
             // it's no typedef to an class and no class itself
             @throw [NSException exceptionWithName:NSInvalidArgumentException reason:@"Expected invocation with object return type. Did you mean to use andReturnValue: instead?" userInfo:nil];
         }
-    }
+    } else {
+		[returnValue retain];
+	}
 	[anInvocation setReturnValue:&returnValue];
 }
 


### PR DESCRIPTION
ARC managed calling code releases the value, causing an exception.

This is documented on StackOverflow:
    http://stackoverflow.com/questions/15345899/unexpected-crash-using-ocmock-mocking-mutablecopy-on-an-nsstring

The following code crashes, for example, when the compiler auto generates
a [foo release] during dealloc.

```
NSString *string = [OCMockObject mockForClass:NSString.class];
NSMutableString *copy = [@"foo" mutableCopy];
id foo = [(NSString *) [[(id) string expect] andReturn:copy] mutableCopy];
```

It may be that not all returned values need releasing and this is a special
circumstance because the compiler knows that foo is a Toll Free Bridged
data type. However, a memory leak in a test is preferable to a test that
crashes.
