### PR TITLE
Fix compilation in 32 bit mode.

### DIFF
--- a/Source/OCMock/OCMockObject.m
+++ b/Source/OCMock/OCMockObject.m
@@ -143,7 +143,7 @@
 	if([expectations count] > 0)
 	{
 		[NSException raise:NSInternalInconsistencyException format:@"%@ : %ld expected methods were not invoked: %@", 
-			[self description], [expectations count], [self _recorderDescriptions:YES]];
+			[self description], (unsigned long)[expectations count], [self _recorderDescriptions:YES]];
 	}
 	if([exceptions count] > 0)
 	{

--- a/Source/OCMock/OCObserverMockObject.m
+++ b/Source/OCMock/OCObserverMockObject.m
@@ -54,7 +54,7 @@
 	if([recorders count] > 0)
 	{
 		[NSException raise:NSInternalInconsistencyException format:@"%@ : %ld expected notifications were not observed.", 
-		 [self description], [recorders count]];
+		 [self description], (unsigned long)[recorders count]];
 	}
 }
 


### PR DESCRIPTION
NSUInteger is an unsigned int in 32 bit mode, but an unsigned long in 64 bit mode. Commit aec3dbb5fa1baffa800df6b6e84dfb227f6a0ec7 switched %d to %ld, fixing the compile for 64 bits and breaking it for 32. This change makes it compile everywhere.
