### PR TITLE
Fix warnings when formatting exceptions.

### DIFF
--- a/Source/OCMock/OCMockObject.m
+++ b/Source/OCMock/OCMockObject.m
@@ -142,8 +142,8 @@
 	}
 	if([expectations count] > 0)
 	{
-		[NSException raise:NSInternalInconsistencyException format:@"%@ : %ld expected methods were not invoked: %@", 
-			[self description], [expectations count], [self _recorderDescriptions:YES]];
+		[NSException raise:NSInternalInconsistencyException format:@"%@ : %lu expected methods were not invoked: %@",
+			[self description], (unsigned long)[expectations count], [self _recorderDescriptions:YES]];
 	}
 	if([exceptions count] > 0)
 	{

--- a/Source/OCMock/OCObserverMockObject.m
+++ b/Source/OCMock/OCObserverMockObject.m
@@ -53,8 +53,8 @@
 	}
 	if([recorders count] > 0)
 	{
-		[NSException raise:NSInternalInconsistencyException format:@"%@ : %ld expected notifications were not observed.", 
-		 [self description], [recorders count]];
+		[NSException raise:NSInternalInconsistencyException format:@"%@ : %lu expected notifications were not observed.",
+		 [self description], (unsigned long)[recorders count]];
 	}
 }
 


### PR DESCRIPTION
The compiler generates Format String Issue warnings when formatting numbers for the description of NSExceptions. The fix is to simply cast the number to the appropriate type.
