### PR TITLE
Adding a parameter name to checkWithBlock:

### DIFF
--- a/Source/OCMock/OCMArg.h
+++ b/Source/OCMock/OCMArg.h
@@ -16,7 +16,7 @@
 + (id)isNotEqual:(id)value;
 + (id)checkWithSelector:(SEL)selector onObject:(id)anObject;
 #if NS_BLOCKS_AVAILABLE
-+ (id)checkWithBlock:(BOOL (^)(id))block;
++ (id)checkWithBlock:(BOOL (^)(id obj))block;
 #endif
 
 // manipulating arguments


### PR DESCRIPTION
This avoids manually inserting a name when using Xcode autocompletion for the block.
