### PR TITLE
Fixed bug for stubbed class methods

### DIFF
--- a/Source/OCMock/OCClassMockObject.m
+++ b/Source/OCMock/OCClassMockObject.m
@@ -103,7 +103,13 @@ static NSMutableDictionary *mockTable;
 	Class metaClass = objc_getMetaClass(class_getName(mockedClass));
 	
 	IMP forwarderImp = [metaClass instanceMethodForSelector:@selector(aMethodThatMustNotExist)];
-	IMP replacedMethod = class_replaceMethod(metaClass, method_getName(originalMethod), forwarderImp, method_getTypeEncoding(originalMethod));
+    
+    IMP replacedMethod = nil;
+    if (class_addMethod(metaClass, selector, method_getImplementation(originalMethod), method_getTypeEncoding(originalMethod))) {
+        replacedMethod = class_replaceMethod(metaClass, method_getName(originalMethod), forwarderImp, method_getTypeEncoding(originalMethod));
+    } else {
+        replacedMethod = method_setImplementation(originalMethod, forwarderImp);
+    }
     
 	[replacedClassMethods setObject:[NSValue valueWithPointer:replacedMethod] forKey:NSStringFromSelector(selector)];
 }

--- a/Source/OCMockTests/OCMockObjectClassMethodMockingTests.m
+++ b/Source/OCMockTests/OCMockObjectClassMethodMockingTests.m
@@ -34,6 +34,13 @@
 
 @end
 
+@interface TestSubClassWithClassMethods : TestClassWithClassMethods
+
+@end
+
+@implementation TestSubClassWithClassMethods
+
+@end
 
 
 @implementation OCMockObjectClassMethodMockingTests
@@ -57,6 +64,16 @@
     [mock stopMocking];
     
     STAssertEqualObjects(@"Foo-ClassMethod", [TestClassWithClassMethods foo], @"Should not have stubbed class method.");
+}
+
+- (void)testSubClassReceivesMethodsAfterStopWasCalled
+{
+    id mock = [OCMockObject mockForClass:[TestSubClassWithClassMethods class]];
+    
+    [[[[mock stub] classMethod] andReturn:@"mocked"] foo];
+    [mock stopMocking];
+    
+    STAssertEqualObjects(@"Foo-ClassMethod", [TestSubClassWithClassMethods foo], @"Should not have stubbed class method.");
 }
 
 - (void)testClassReceivesMethodAgainWhenExpectedCallOccurred


### PR DESCRIPTION
A class contains "+ (void)foo" method and B class is inherited from A one. Mocking B class, stubbing "+ (void)foo" and then removing all stubbs by calling "stopMocking" did not work as expected. Later calls to [B foo] native (non-stubbed) implementation failed.

Also, I've updated OCMockObjectClassMethodMockingTests test case to include test which reproduces this issue.

Please, let me know if there is anything wrong with this approach.
