### PR TITLE
Added support for mocking functions that return structs.

### DIFF
--- a/Source/OCMock/OCMockRecorder.h
+++ b/Source/OCMock/OCMockRecorder.h
@@ -22,6 +22,7 @@
 
 - (id)andReturn:(id)anObject;
 - (id)andReturnValue:(NSValue *)aValue;
+- (id)andReturnStruct:(void*)aValue objCType:(const char*)type;
 - (id)andThrow:(NSException *)anException;
 - (id)andPost:(NSNotification *)aNotification;
 - (id)andCall:(SEL)selector onObject:(id)anObject;

--- a/Source/OCMock/OCMockRecorder.m
+++ b/Source/OCMock/OCMockRecorder.m
@@ -68,6 +68,13 @@
 	return self;
 }
 
+- (id)andReturnStruct:(void*)aValue objCType:(const char*)type
+{
+    NSValue *wrappedValue = [NSValue valueWithBytes:aValue objCType:type];
+    
+    return [self andReturnValue:wrappedValue];
+}
+
 - (id)andThrow:(NSException *)anException
 {
 	[invocationHandlers addObject:[[[OCMExceptionReturnValueProvider alloc] initWithValue:anException] autorelease]];

--- a/Source/OCMockTests/OCMockObjectTests.m
+++ b/Source/OCMockTests/OCMockObjectTests.m
@@ -351,6 +351,18 @@ static NSString *TestNotification = @"TestNotification";
 	STAssertNil(returnValue, @"Should have returned stubbed value, which is nil.");
 }
 
+- (void)testReturnsStrubbedStructReturnValue
+{
+    NSString* string = @"This is a test string";
+    
+    NSRange range = NSMakeRange(3, 1);
+    OCMockObject* mockString = [OCMockObject partialMockForObject:string];
+    [[[mockString stub] andReturnStruct:&range objCType:@encode(NSRange)] rangeOfString:OCMOCK_ANY];
+    
+    NSRange fakeRange = [string rangeOfString:@"Not here"];
+    
+    STAssertEquals(fakeRange, range, @"Should have returned overriding range");
+}
 
 // --------------------------------------------------------------------------------------
 //	beyond stubbing: raising exceptions, posting notifications, etc.

--- a/Source/OCMockTests/OCMockRecorderTests.m
+++ b/Source/OCMockTests/OCMockRecorderTests.m
@@ -6,6 +6,7 @@
 #import "OCMockRecorderTests.h"
 #import <OCMock/OCMockRecorder.h>
 #import "OCMReturnValueProvider.h"
+#import "OCMBoxedReturnValueProvider.h"
 #import "OCMExceptionReturnValueProvider.h"
 #import "OCMArg.h"
 
@@ -82,6 +83,19 @@
 	STAssertEquals((NSUInteger)1, [handlerList count], @"Should have added one handler.");
 	STAssertEqualObjects([OCMExceptionReturnValueProvider class], [[handlerList objectAtIndex:0] class], @"Should have added correct handler.");
 	
+}
+
+- (void)testAndReturnsStruct
+{
+    NSRange range = NSMakeRange(1, 2);
+    
+    OCMockRecorder *recorder = [[[OCMockRecorder alloc] initWithSignatureResolver:[NSString string]] autorelease];
+	[recorder andReturnStruct:&range objCType:@encode(NSRange)];
+    
+    NSArray *handlerList = [recorder invocationHandlers];
+	
+	STAssertEquals((NSUInteger)1, [handlerList count], @"Should have added one handler.");
+	STAssertEqualObjects([OCMBoxedReturnValueProvider class], [[handlerList objectAtIndex:0] class], @"Should have added correct handler.");
 }
 
 @end


### PR DESCRIPTION
Implementing ideas referenced:

http://stackoverflow.com/questions/16559191/returning-cgrect-from-mocked-method-crashes
http://codeforfun.wordpress.com/2009/02/07/ocmock-return-a-struct/

Instead of lots of people doing "one-off's" that add this support, figured returning structs could pretty easily be a first-level feature.

Example of how it can be used:

```
OCMockObject* mockString = [OCMockObject partialMockForObject:string];
[[[mockString stub] andReturnStruct:&range objCType:@encode(NSRange)] rangeOfString:OCMOCK_ANY];
```
