### PR TITLE
When using partial mocks, override the -class method to return the original class

### DIFF
--- a/Source/OCMock/OCPartialMockObject.h
+++ b/Source/OCMock/OCPartialMockObject.h
@@ -8,11 +8,13 @@
 @interface OCPartialMockObject : OCClassMockObject 
 {
 	NSObject	*realObject;
+	Class		realObjectReportedClass;
 }
 
 - (id)initWithObject:(NSObject *)anObject;
 
 - (NSObject *)realObject;
+- (Class)realObjectReportedClass;
 
 - (void)stopMocking;
 

--- a/Source/OCMockTests/OCMockObjectPartialMocksTests.h
+++ b/Source/OCMockTests/OCMockObjectPartialMocksTests.h
@@ -6,5 +6,8 @@
 #import <SenTestingKit/SenTestingKit.h>
 
 @interface OCMockObjectPartialMocksTests : SenTestCase
+{
+    int numKVOCallbacks;
+}
 
 @end

--- a/Source/OCMockTests/OCMockObjectPartialMocksTests.m
+++ b/Source/OCMockTests/OCMockObjectPartialMocksTests.m
@@ -5,6 +5,7 @@
 
 #import <OCMock/OCMock.h>
 #import "OCMockObjectPartialMocksTests.h"
+#import <objc/runtime.h>
 
 #pragma mark   Helper classes
 
@@ -23,10 +24,16 @@
 
 
 @interface TestClassThatCallsSelf : NSObject
+{
+    int methodInt;
+}
+
 - (NSString *)method1;
 - (NSString *)method2;
 - (NSRect)methodRect1;
 - (NSRect)methodRect2;
+- (int)methodInt;
+- (void)setMethodInt:(int)anInt;
 @end
 
 @implementation TestClassThatCallsSelf
@@ -52,6 +59,16 @@
 - (NSRect)methodRect2
 {
 	return NSMakeRect(10, 10, 10, 10);
+}
+
+- (int)methodInt
+{
+	return methodInt;
+}
+
+- (void)setMethodInt:(int)anInt
+{
+	methodInt = anInt;
 }
 
 @end
@@ -114,6 +131,93 @@
 	STAssertEquals(NSZeroRect, [mock methodRect1], @"Should have called through to stubbed method.");
 }
 
+
+- (void)testPartialMockClassOverrideReportsOriginalClass
+{
+	TestClassThatCallsSelf *realObject = [[[TestClassThatCallsSelf alloc] init] autorelease];
+	Class origClass = [realObject class];
+	id mock = [OCMockObject partialMockForObject:realObject];
+	STAssertEqualObjects([realObject class], origClass, @"Override of -class method did not work");
+	STAssertFalse(origClass == object_getClass(realObject), @"Subclassing did not work");
+	[mock stopMocking];
+	STAssertEqualObjects([realObject class], origClass, @"Classes different after stopMocking");
+	STAssertEqualObjects(object_getClass(realObject), origClass, @"Classes different after stopMocking");
+}
+
+- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context
+{
+	numKVOCallbacks++;
+}
+
+#pragma mark   Tests for KVO interaction with mocks
+
+/* Starting KVO observations on an already-mocked object generally should work. */
+- (void)testAddingKVOObserverOnPartialMock
+{
+	static char *MyContext;
+	TestClassThatCallsSelf *realObject = [[[TestClassThatCallsSelf alloc] init] autorelease];
+	Class origClass = [realObject class];
+
+	id mock = [OCMockObject partialMockForObject:realObject];
+	Class ourSubclass = object_getClass(realObject);
+
+	[realObject addObserver:self forKeyPath:@"methodInt" options:NSKeyValueObservingOptionNew context:MyContext];
+	Class kvoClass = object_getClass(realObject);
+
+	/* KVO additionally overrides the -class method, but they return the superclass of their special
+	   subclass, which in this case is the special mock subclass */
+	STAssertEqualObjects([realObject class], ourSubclass, @"KVO override of class did not return our subclass");
+	STAssertFalse(ourSubclass == kvoClass, @"KVO with subclass did not work");
+
+	[realObject setMethodInt:45];
+	STAssertEquals(numKVOCallbacks, 1, @"did not get subclass KVO notification");
+	[mock setMethodInt:47];
+	STAssertEquals(numKVOCallbacks, 2, @"did not get mock KVO notification");
+
+	[realObject removeObserver:self forKeyPath:@"methodInt" context:MyContext];
+	STAssertEqualObjects([realObject class], origClass, @"Classes different after stopKVO");
+	STAssertEqualObjects(object_getClass(realObject), ourSubclass, @"Classes different after stopKVO");
+
+	[mock stopMocking];
+	STAssertEqualObjects([realObject class], origClass, @"Classes different after stopMocking");
+	STAssertEqualObjects(object_getClass(realObject), origClass, @"Classes different after stopMocking");
+}
+
+/* Mocking a class which already has KVO observations does not work, but does not crash. */
+- (void)testPartialMockOnKVOObserved
+{
+	static char *MyContext;
+	TestClassThatCallsSelf *realObject = [[[TestClassThatCallsSelf alloc] init] autorelease];
+	Class origClass = [realObject class];
+    
+	[realObject addObserver:self forKeyPath:@"methodInt" options:NSKeyValueObservingOptionNew context:MyContext];
+	Class kvoClass = object_getClass(realObject);
+
+	id mock = [OCMockObject partialMockForObject:realObject];
+	Class ourSubclass = object_getClass(realObject);
+    
+	STAssertEqualObjects([realObject class], origClass, @"We did not preserve the original [self class]");
+	STAssertFalse(ourSubclass == kvoClass, @"KVO with subclass did not work");
+    
+	/* Due to the way we replace the object's class, the KVO class gets overwritten and
+	   KVO notifications stop functioning.  If we did not do this, the presence of the mock
+	   subclass would cause KVO to crash, at least without further tinkering. */
+	[realObject setMethodInt:45];
+//	STAssertEquals(numKVOCallbacks, 1, @"did not get subclass KVO notification");
+	STAssertEquals(numKVOCallbacks, 0, @"got subclass KVO notification");
+	[mock setMethodInt:47];
+//	STAssertEquals(numKVOCallbacks, 2, @"did not get mock KVO notification");
+	STAssertEquals(numKVOCallbacks, 0, @"got mock KVO notification");
+
+	[mock stopMocking];
+	STAssertEqualObjects([realObject class], origClass, @"Classes different after stopMocking");
+//	STAssertEqualObjects(object_getClass(realObject), kvoClass, @"KVO class different after stopMocking");
+	STAssertEqualObjects(object_getClass(realObject), origClass, @"class different after stopMocking");
+
+	[realObject removeObserver:self forKeyPath:@"methodInt" context:MyContext];
+	STAssertEqualObjects([realObject class], origClass, @"Classes different after stopKVO");
+	STAssertEqualObjects(object_getClass(realObject), origClass, @"Classes different after stopKVO");
+}
 
 #pragma mark   Tests for end of stubbing with partial mocks
 


### PR DESCRIPTION
When using partial mocks, override the -class method to return the original class.  This lets things like [NSBundle bundleForClass:[self class]] to continue to work as expected when mocked.

KVO does this as well with its subclasses.

I did keep one bit of existing behavior which is technically not correct; we mock the result of [self class] rather than the actual runtime class, which is not always the same.  In particular, this feature is what stops KVO notifications from being sent, as the private class which KVO creates is effectively removed.  However, if we subclassed the KVO class instead, we would get crashes as the KVO overrides are sensitive to the "isa" value being correct from its perspective.  It is probably possible to make most things work with KVO but it is a fair bit more involved.  I did add a couple of test cases to show current behavior with KVO;  adding an observer to an already-mocked object is fine and should work, but mocking a class which already has KVO observers basically disables KVO (but does not crash).

This branch is off of master; if you choose to merge #44 it will have a couple of small conflicts.
