### PR TITLE
Extended OCMockObject with verifyWithDelay that takes a timeout.

### DIFF
--- a/Source/Changes.txt
+++ b/Source/Changes.txt
@@ -1,6 +1,10 @@
 Chronological listing of changes. More detail is usually found in the Git commit messages
 and/or the pull requests.
 
+2014-01-16
+
+* Extended OCMockObject with verifyWithDelay (Charles Harley, Daniel Doubrovkine)
+
 2013-12-04
 
 * Added implementation for Apple-interal NSIsKind informal protocol (Brian Gerstle)

--- a/Source/OCMock/OCMockObject.h
+++ b/Source/OCMock/OCMockObject.h
@@ -33,6 +33,7 @@
 - (id)reject;
 
 - (void)verify;
+- (void)verifyWithDelay:(NSTimeInterval)delay;
 
 - (void)stopMocking;
 

--- a/Source/OCMock/OCMockObject.m
+++ b/Source/OCMock/OCMockObject.m
@@ -152,6 +152,21 @@
 	}
 }
 
+- (void)verifyWithDelay:(NSTimeInterval)delay {
+    NSTimeInterval i = 0;
+    while (i < delay) {
+        @try {
+            [self verify];
+            return;
+        } @catch (NSException *e) {}
+        
+        [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.5]];
+        i += 0.5;
+    }
+    
+    [self verify];
+}
+
 - (void)stopMocking
 {
     // no-op for mock objects that are not class object or partial mocks


### PR DESCRIPTION
How do you feel about adding a `verifyWithDelay`? It could of course be made into a separate pod (I will if you don't like this), but I think it makes sense to make it easy for users of OCMock as it's, IMO, a pretty common scenario.

It looks like everybody is rolling out their own mock with delay. In our project we have lots of callback asynchrony going on and eventually it results in some dialog popup.

This is code from https://gist.github.com/CharlesHarley/7411681, cc: @CharlesHarley.

This btw is also motivation for implementing Expecta expectations (see https://github.com/specta/expecta/issues/71), which has a `.will.` that basically does the same thing more generically.
