### PR TITLE
Support -andForwardToRealObject when stubbing/expecting class methods

### DIFF
--- a/Source/OCMock/OCClassMockObject.h
+++ b/Source/OCMock/OCClassMockObject.h
@@ -19,3 +19,5 @@
 - (void)setupForwarderForClassMethodSelector:(SEL)selector;
 
 @end
+
+extern NSString *OCMRealMethodAliasPrefix;

--- a/Source/OCMock/OCClassMockObject.m
+++ b/Source/OCMock/OCClassMockObject.m
@@ -9,6 +9,9 @@
 #import "NSObject+OCMAdditions.h"
 
 
+NSString *OCMRealMethodAliasPrefix = @"ocmock_replaced_";
+
+
 @implementation OCClassMockObject
 
 #pragma mark  Mock table
@@ -120,6 +123,9 @@ static NSMutableDictionary *mockTable;
     Class metaClass = object_getClass(mockedClass);
     IMP forwarderIMP = [metaClass instanceMethodForwarderForSelector:selector];
     class_replaceMethod(metaClass, method_getName(method), forwarderIMP, method_getTypeEncoding(method));
+    
+    SEL aliasSelector = NSSelectorFromString([OCMRealMethodAliasPrefix stringByAppendingString:NSStringFromSelector(selector)]);
+    class_addMethod(metaClass, aliasSelector, originalIMP, method_getTypeEncoding(method));
 }
 
 - (void)removeForwarderForClassMethodSelector:(SEL)selector

--- a/Source/OCMock/OCMockRecorder.m
+++ b/Source/OCMock/OCMockRecorder.m
@@ -15,6 +15,7 @@
 #import "OCMIndirectReturnValueProvider.h"
 #import "OCMNotificationPoster.h"
 #import "OCMBlockCaller.h"
+#import "OCMRealObjectForwarder.h"
 #import "NSInvocation+OCMAdditions.h"
 
 @interface NSObject(HCMatcherDummy)
@@ -98,7 +99,12 @@
 
 - (id)andForwardToRealObject
 {
-	[NSException raise:NSInternalInconsistencyException format:@"Method %@ can only be used with partial mocks.",
+	if (recordedAsClassMethod) {
+		[invocationHandlers addObject:[[[OCMRealObjectForwarder alloc] init] autorelease]];
+		return self;
+	}
+
+	[NSException raise:NSInternalInconsistencyException format:@"Method %@ can only be used with partial mocks and class methods.",
 	 NSStringFromSelector(_cmd)];
 	return self; // keep compiler happy
 }

--- a/Source/OCMock/OCPartialMockObject.h
+++ b/Source/OCMock/OCPartialMockObject.h
@@ -20,6 +20,3 @@
 - (void)setupForwarderForSelector:(SEL)selector;
 
 @end
-
-
-extern NSString *OCMRealMethodAliasPrefix;

--- a/Source/OCMock/OCPartialMockObject.m
+++ b/Source/OCMock/OCPartialMockObject.m
@@ -14,9 +14,6 @@
 - (void)forwardInvocationForRealObject:(NSInvocation *)anInvocation;
 @end 
 
-
-NSString *OCMRealMethodAliasPrefix = @"ocmock_replaced_";
-
 @implementation OCPartialMockObject
 
 

--- a/Source/OCMockTests/OCMockObjectClassMethodMockingTests.m
+++ b/Source/OCMockTests/OCMockObjectClassMethodMockingTests.m
@@ -222,5 +222,16 @@
     STAssertEqualObjects(@"Bar-ClassMethod", [TestClassWithClassMethods bar], @"Should have 'unstubbed' class method 'bar'.");
 }
 
+- (void)testForwardToRealObject
+{
+    NSString *classValue = [TestClassWithClassMethods foo];
+    id mock = [OCMockObject mockForClass:[TestClassWithClassMethods class]];
+    [[[[mock expect] classMethod] andForwardToRealObject] foo];
+
+    NSString *result = [TestClassWithClassMethods foo];
+    STAssertEqualObjects(result, classValue, nil);
+    STAssertNoThrow([mock verify], nil);
+}
+
 
 @end


### PR DESCRIPTION
Support -andForwardToRealObject when stubbing/expecting class methods.

With this implementation, it requires an explicit -classMethod be invoked before andForwardToRealObject, rather than also supporting the mode where an unambiguous class method is determined later.  Not ideal but we don't know the latter situation until later in the process, which is after the invocation handler needs to be added.

One option would be to unconditionally always add the handler, then move the invalid-andForwardToRealObject-checking logic inside the handler itself (if the target is a proxy and not an OCPartalMockObject, then raise the exception).  This means the error is an actual runtime call rather than getting flagged during the mock setup.  It will trigger if andForwardToRealObject is used on a non-partial mock and non-class method and that method is actually called, but if not called it would leave the error in the mock setup unflagged, which could be more surprising if the runtime changed to call the method.  This does work, but unsure if not flagging the error immediately is a big deal or not.

Another option would be to always add the handler, but then flag in OCMockRecorder that andForwardToRealObject had been called, then later on when the method signature is supplied check to see if the forwardToRealObject is valid at that point (partial mock or class method).  This also wouldn't be too hard, though would probably need a new method which OCPartialMockRecorder could override since that would involve changing logic which is currently shared by the two classes.  Not hard though.

So.... which option does people think is best?  The pull request as posted, or option 2 or 3 as mentioned above?  I'd be happy to update the pull request (or post others) with the other options.
