### PR TITLE
Implement -andForwardToRealObject for class method mocks, option 2

### DIFF
--- a/Source/OCMock/OCClassMockObject.h
+++ b/Source/OCMock/OCClassMockObject.h
@@ -21,3 +21,5 @@
 
 
 @end
+
+extern NSString *OCMRealMethodAliasPrefix;

--- a/Source/OCMock/OCClassMockObject.m
+++ b/Source/OCMock/OCClassMockObject.m
@@ -9,6 +9,9 @@
 #import "NSObject+OCMAdditions.h"
 
 
+NSString *OCMRealMethodAliasPrefix = @"ocmock_replaced_";
+
+
 @implementation OCClassMockObject
 
 #pragma mark  Mock table
@@ -120,6 +123,9 @@ static NSMutableDictionary *mockTable;
     Class metaClass = object_getClass(mockedClass);
     IMP forwarderIMP = [metaClass instanceMethodForwarderForSelector:selector];
     class_replaceMethod(metaClass, method_getName(method), forwarderIMP, method_getTypeEncoding(method));
+    
+    SEL aliasSelector = NSSelectorFromString([OCMRealMethodAliasPrefix stringByAppendingString:NSStringFromSelector(selector)]);
+    class_addMethod(metaClass, aliasSelector, originalIMP, method_getTypeEncoding(method));
 }
 
 - (void)removeForwarderForClassMethodSelector:(SEL)selector

--- a/Source/OCMock/OCMRealObjectForwarder.m
+++ b/Source/OCMock/OCMRealObjectForwarder.m
@@ -17,11 +17,20 @@
 	SEL aliasedSelector = NSSelectorFromString([OCMRealMethodAliasPrefix stringByAppendingString:NSStringFromSelector(invocationSelector)]);
 	
 	[anInvocation setSelector:aliasedSelector];
-	if([invocationTarget isProxy] && (class_getInstanceMethod([invocationTarget mockObjectClass], @selector(realObject))))
+	if ([invocationTarget isProxy])
 	{
-		// the method has been invoked on the mock, we need to change the target to the real object
-		[anInvocation setTarget:[(OCPartialMockObject *)invocationTarget realObject]];
-	} 
+	    if (class_getInstanceMethod([invocationTarget mockObjectClass], @selector(realObject)))
+	    {
+	        // the method has been invoked on the mock, we need to change the target to the real object
+	        [anInvocation setTarget:[(OCPartialMockObject *)invocationTarget realObject]];
+	    }
+	    else
+	    {
+	        [NSException raise:NSInternalInconsistencyException
+	                    format:@"Method andForwardToRealObject can only be used with partial mocks and class methods."];
+	    }
+	}
+
 	[anInvocation invoke];
 }
 

--- a/Source/OCMock/OCMockRecorder.m
+++ b/Source/OCMock/OCMockRecorder.m
@@ -15,6 +15,7 @@
 #import "OCMIndirectReturnValueProvider.h"
 #import "OCMNotificationPoster.h"
 #import "OCMBlockCaller.h"
+#import "OCMRealObjectForwarder.h"
 #import "NSInvocation+OCMAdditions.h"
 
 @interface NSObject(HCMatcherDummy)
@@ -98,9 +99,8 @@
 
 - (id)andForwardToRealObject
 {
-	[NSException raise:NSInternalInconsistencyException format:@"Method %@ can only be used with partial mocks.",
-	 NSStringFromSelector(_cmd)];
-	return self; // keep compiler happy
+    [invocationHandlers addObject:[[[OCMRealObjectForwarder alloc] init] autorelease]];
+    return self;
 }
 
 

--- a/Source/OCMock/OCPartialMockObject.h
+++ b/Source/OCMock/OCPartialMockObject.h
@@ -20,6 +20,3 @@
 - (void)setupForwarderForSelector:(SEL)selector;
 
 @end
-
-
-extern NSString *OCMRealMethodAliasPrefix;

--- a/Source/OCMock/OCPartialMockObject.m
+++ b/Source/OCMock/OCPartialMockObject.m
@@ -14,9 +14,6 @@
 - (void)forwardInvocationForRealObject:(NSInvocation *)anInvocation;
 @end 
 
-
-NSString *OCMRealMethodAliasPrefix = @"ocmock_replaced_";
-
 @implementation OCPartialMockObject
 
 

--- a/Source/OCMock/OCPartialMockRecorder.m
+++ b/Source/OCMock/OCPartialMockRecorder.m
@@ -10,13 +10,6 @@
 
 @implementation OCPartialMockRecorder
 
-- (id)andForwardToRealObject
-{
-	[invocationHandlers addObject:[[[OCMRealObjectForwarder	alloc] init] autorelease]];
-	return self;
-}
-
-
 - (void)forwardInvocation:(NSInvocation *)anInvocation
 {
 	[super forwardInvocation:anInvocation];

--- a/Source/OCMockTests/OCMockObjectClassMethodMockingTests.m
+++ b/Source/OCMockTests/OCMockObjectClassMethodMockingTests.m
@@ -222,5 +222,36 @@
     STAssertEqualObjects(@"Bar-ClassMethod", [TestClassWithClassMethods bar], @"Should have 'unstubbed' class method 'bar'.");
 }
 
+- (void)testForwardToRealObject
+{
+    NSString *classFooValue = [TestClassWithClassMethods foo];
+    NSString *classBarValue = [TestClassWithClassMethods bar];
+    id mock = [OCMockObject mockForClass:[TestClassWithClassMethods class]];
+
+    [[[[mock expect] classMethod] andForwardToRealObject] foo];
+    NSString *result = [TestClassWithClassMethods foo];
+    STAssertEqualObjects(result, classFooValue, nil);
+    STAssertNoThrow([mock verify], nil);
+    
+    [[[mock expect] andForwardToRealObject] foo];
+    result = [TestClassWithClassMethods foo];
+    STAssertEqualObjects(result, classFooValue, nil);
+    STAssertNoThrow([mock verify], nil);
+
+    [[[[mock expect] classMethod] andForwardToRealObject] bar];
+    result = [TestClassWithClassMethods bar];
+    STAssertEqualObjects(result, classBarValue, nil);
+    STAssertNoThrow([mock verify], nil);
+    
+    [[[[mock expect] classMethod] andForwardToRealObject] bar];
+    STAssertThrowsSpecificNamed([mock bar], NSException, NSInternalInconsistencyException, nil);
+
+    [[[mock expect] andForwardToRealObject] bar];
+    STAssertThrowsSpecificNamed([mock bar], NSException, NSInternalInconsistencyException, @"Did not get the exception saying andForwardToRealObject not supported");
+
+    [[[mock expect] andForwardToRealObject] foo];
+    STAssertThrows([mock foo], nil);
+}
+
 
 @end


### PR DESCRIPTION
Implement -andForwardToRealObject for class method mocks.  This version can no longer tell the user up front of illegal uses of andForwardToRealObject, but will instead throw the same error message later at runtime if the handler is actually used in an illegal situation.  But, it does not require the explicit use of -classMethod when mocking -- it should work as naturally as andForwardToRealObject does for partial mocks.

Either this pull request or #64 should be added, not both.  See that pull request for more discussion.
