### PR TITLE
Fix exception when an object has a nil description

### DIFF
--- a/Source/OCMock/NSInvocation+OCMAdditions.m
+++ b/Source/OCMock/NSInvocation+OCMAdditions.m
@@ -200,8 +200,7 @@
 	[self getArgument:&object atIndex:anInt];
 	if (object == nil)
 		return @"nil";
-	
-	if(![object isProxy] && [object isKindOfClass:[NSString class]])
+	else if(![object isProxy] && [object isKindOfClass:[NSString class]])
 		return [NSString stringWithFormat:@"@\"%@\"", [object description]];
 	else
 		// The description cannot be nil, if it is then replace it


### PR DESCRIPTION
An exception is thrown when an object parameter of an invocation has a nil description as the result of [object description] is directly passed to appendString: in the invocationDescription method.  This pull request fixes the issue by returning an empty string instead of nil.
