### PR TITLE
Add convenience methods on NSObject for mocking

### DIFF
--- a/Source/OCMock.xcodeproj/project.pbxproj
+++ b/Source/OCMock.xcodeproj/project.pbxproj
@@ -134,6 +134,9 @@
 		2FA28D38ED9D83A3E0A620B3 /* NSObject+OCMAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 2FA28991BEFD67DEF2CCF7D2 /* NSObject+OCMAdditions.m */; };
 		2FA28E1EB6B8536785258DF5 /* OCMInvocationMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FA28CCC33B99D6B658E7AF8 /* OCMInvocationMatcher.h */; };
 		2FA28E90A41960260D74EE8E /* OCMMacroState.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FA28ED9AC631B1E88BF0AF2 /* OCMMacroState.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8CC0E0201908E83600AE891B /* NSObject+OCMMockAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 8CC0E01E1908E83600AE891B /* NSObject+OCMMockAdditions.h */; };
+		8CC0E0211908E83600AE891B /* NSObject+OCMMockAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 8CC0E01F1908E83600AE891B /* NSObject+OCMMockAdditions.m */; };
+		8CC0E0231908EB0F00AE891B /* NSObjectOCMMockAdditionsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8CC0E0221908EB0F00AE891B /* NSObjectOCMMockAdditionsTests.m */; };
 		D31108BA1828DB8700737925 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = D31108B81828DB8700737925 /* InfoPlist.strings */; };
 		D31108C31828DBD600737925 /* OCMockObjectTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 03B316251463350E0052CD09 /* OCMockObjectTests.m */; };
 		D31108C41828DBD600737925 /* OCMockObjectPartialMocksTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 03AC5C1416DF9FA500D82ECD /* OCMockObjectPartialMocksTests.m */; };
@@ -244,6 +247,9 @@
 		2FA28DEDB9163597B7C49F3D /* NSMethodSignatureOCMAdditionsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSMethodSignatureOCMAdditionsTests.m; sourceTree = "<group>"; };
 		2FA28ED9AC631B1E88BF0AF2 /* OCMMacroState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OCMMacroState.h; sourceTree = "<group>"; };
 		2FA28EDBF243639C57F88A1B /* OCMArgTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OCMArgTests.m; sourceTree = "<group>"; };
+		8CC0E01E1908E83600AE891B /* NSObject+OCMMockAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSObject+OCMMockAdditions.h"; sourceTree = "<group>"; };
+		8CC0E01F1908E83600AE891B /* NSObject+OCMMockAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSObject+OCMMockAdditions.m"; sourceTree = "<group>"; };
+		8CC0E0221908EB0F00AE891B /* NSObjectOCMMockAdditionsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSObjectOCMMockAdditionsTests.m; sourceTree = "<group>"; };
 		D31108AD1828DB8700737925 /* OCMockLibTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OCMockLibTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D31108B71828DB8700737925 /* OCMockLibTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "OCMockLibTests-Info.plist"; sourceTree = "<group>"; };
 		D31108B91828DB8700737925 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -373,21 +379,22 @@
 		03565A3318F0566F003AE91E /* OCMockTests */ = {
 			isa = PBXGroup;
 			children = (
-				03B316251463350E0052CD09 /* OCMockObjectTests.m */,
-				03AC5C1416DF9FA500D82ECD /* OCMockObjectPartialMocksTests.m */,
-				039F91C516EFB493006C3D70 /* OCMockObjectClassMethodMockingTests.m */,
-				2FA286BFBD8B9D068B41E7EF /* OCMockObjectProtocolMocksTests.m */,
-				03E98D4F18F310EE00522D42 /* OCMockObjectMacroTests.m */,
-				0354D71F16F23AF5001766BB /* OCMockObjectForwardingTargetTests.m */,
-				03B316231463350E0052CD09 /* OCMockObjectHamcrestTests.mm */,
-				03B316211463350E0052CD09 /* OCMConstraintTests.m */,
-				03B316271463350E0052CD09 /* OCMockRecorderTests.m */,
-				2FA28EDBF243639C57F88A1B /* OCMArgTests.m */,
-				03B316291463350E0052CD09 /* OCObserverMockObjectTests.m */,
 				03B3161F1463350E0052CD09 /* NSInvocationOCMAdditionsTests.m */,
 				2FA28DEDB9163597B7C49F3D /* NSMethodSignatureOCMAdditionsTests.m */,
-				03565A3418F0566F003AE91E /* Supporting Files */,
+				8CC0E0221908EB0F00AE891B /* NSObjectOCMMockAdditionsTests.m */,
+				2FA28EDBF243639C57F88A1B /* OCMArgTests.m */,
+				03B316211463350E0052CD09 /* OCMConstraintTests.m */,
 				037ECD5318FAD84100AF0E4C /* OCMInvocationMatcherTests.m */,
+				039F91C516EFB493006C3D70 /* OCMockObjectClassMethodMockingTests.m */,
+				0354D71F16F23AF5001766BB /* OCMockObjectForwardingTargetTests.m */,
+				03B316231463350E0052CD09 /* OCMockObjectHamcrestTests.mm */,
+				03E98D4F18F310EE00522D42 /* OCMockObjectMacroTests.m */,
+				03AC5C1416DF9FA500D82ECD /* OCMockObjectPartialMocksTests.m */,
+				2FA286BFBD8B9D068B41E7EF /* OCMockObjectProtocolMocksTests.m */,
+				03B316251463350E0052CD09 /* OCMockObjectTests.m */,
+				03B316271463350E0052CD09 /* OCMockRecorderTests.m */,
+				03B316291463350E0052CD09 /* OCObserverMockObjectTests.m */,
+				03565A3418F0566F003AE91E /* Supporting Files */,
 			);
 			path = OCMockTests;
 			sourceTree = "<group>";
@@ -443,6 +450,8 @@
 				03B3158A146333BF0052CD09 /* NSNotificationCenter+OCMAdditions.m */,
 				2FA28991BEFD67DEF2CCF7D2 /* NSObject+OCMAdditions.m */,
 				2FA28C5F4A475BEC0C28BDC3 /* NSObject+OCMAdditions.h */,
+				8CC0E01E1908E83600AE891B /* NSObject+OCMMockAdditions.h */,
+				8CC0E01F1908E83600AE891B /* NSObject+OCMMockAdditions.m */,
 			);
 			name = "Foundation Additions";
 			sourceTree = "<group>";
@@ -545,6 +554,7 @@
 				03B315AF146333BF0052CD09 /* NSInvocation+OCMAdditions.h in Headers */,
 				03B315B4146333BF0052CD09 /* NSMethodSignature+OCMAdditions.h in Headers */,
 				03B315BE146333BF0052CD09 /* OCClassMockObject.h in Headers */,
+				8CC0E0201908E83600AE891B /* NSObject+OCMMockAdditions.h in Headers */,
 				03B315C8146333BF0052CD09 /* OCMBlockCaller.h in Headers */,
 				03B315CD146333BF0052CD09 /* OCMBoxedReturnValueProvider.h in Headers */,
 				03B315D7146333BF0052CD09 /* OCMExceptionReturnValueProvider.h in Headers */,
@@ -766,6 +776,7 @@
 				03B315C5146333BF0052CD09 /* OCMArg.m in Sources */,
 				03B315CA146333BF0052CD09 /* OCMBlockCaller.m in Sources */,
 				03B315CF146333BF0052CD09 /* OCMBoxedReturnValueProvider.m in Sources */,
+				8CC0E0211908E83600AE891B /* NSObject+OCMMockAdditions.m in Sources */,
 				03B315D4146333BF0052CD09 /* OCMConstraint.m in Sources */,
 				03B315D9146333BF0052CD09 /* OCMExceptionReturnValueProvider.m in Sources */,
 				03B315DE146333BF0052CD09 /* OCMIndirectReturnValueProvider.m in Sources */,
@@ -826,6 +837,7 @@
 				037ECD5418FAD84100AF0E4C /* OCMInvocationMatcherTests.m in Sources */,
 				03565A4418F05721003AE91E /* OCMockObjectProtocolMocksTests.m in Sources */,
 				03565A4B18F05721003AE91E /* NSInvocationOCMAdditionsTests.m in Sources */,
+				8CC0E0231908EB0F00AE891B /* NSObjectOCMMockAdditionsTests.m in Sources */,
 				03565A4618F05721003AE91E /* OCMockObjectHamcrestTests.mm in Sources */,
 				03E98D5018F310EE00522D42 /* OCMockObjectMacroTests.m in Sources */,
 				03565A4A18F05721003AE91E /* OCObserverMockObjectTests.m in Sources */,

--- a/Source/OCMock/NSObject+OCMMockAdditions.h
+++ b/Source/OCMock/NSObject+OCMMockAdditions.h
@@ -1,0 +1,11 @@
+#import <Foundation/Foundation.h>
+
+@class OCMockObject;
+
+@interface NSObject (OCMMockAdditions)
+
++ (id)mock;
++ (id)niceMock;
++ (id)partialMock;
+
+@end

--- a/Source/OCMock/NSObject+OCMMockAdditions.m
+++ b/Source/OCMock/NSObject+OCMMockAdditions.m
@@ -1,0 +1,21 @@
+#import "NSObject+OCMMockAdditions.h"
+#import "OCMockObject.h"
+
+@implementation NSObject (OCMMockAdditions)
+
++ (id)mock
+{
+    return [OCMockObject mockForClass:[self class]];
+}
+
++ (id)niceMock
+{
+    return [OCMockObject niceMockForClass:[self class]];
+}
+
++ (id)partialMock
+{
+    return [OCMockObject partialMockForObject:[self new]];
+}
+
+@end

--- a/Source/OCMock/OCMock.h
+++ b/Source/OCMock/OCMock.h
@@ -10,7 +10,7 @@
 #import <OCMock/OCMLocation.h>
 #import <OCMock/OCMMacroState.h>
 #import <OCMock/NSNotificationCenter+OCMAdditions.h>
-
+#import "NSObject+OCMMockAdditions.h"
 
 #define OCMClassMock(cls) [OCMockObject niceMockForClass:cls]
 

--- a/Source/OCMockTests/NSObjectOCMMockAdditionsTests.m
+++ b/Source/OCMockTests/NSObjectOCMMockAdditionsTests.m
@@ -1,11 +1,3 @@
-//
-//  NSObjectOCMMockAdditionsTests.m
-//  OCMock
-//
-//  Created by Mark Larsen on 4/23/14.
-//  Copyright (c) 2014 Mulle Kybernetik. All rights reserved.
-//
-
 #import <XCTest/XCTest.h>
 #import "NSObject+OCMMockAdditions.h"
 

--- a/Source/OCMockTests/NSObjectOCMMockAdditionsTests.m
+++ b/Source/OCMockTests/NSObjectOCMMockAdditionsTests.m
@@ -1,0 +1,46 @@
+//
+//  NSObjectOCMMockAdditionsTests.m
+//  OCMock
+//
+//  Created by Mark Larsen on 4/23/14.
+//  Copyright (c) 2014 Mulle Kybernetik. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "NSObject+OCMMockAdditions.h"
+
+#import "OCClassMockObject.h"
+#import "OCPartialMockObject.h"
+#import <objc/runtime.h>
+
+@interface NSObjectOCMMockAdditionsTests : XCTestCase
+
+@end
+
+@implementation NSObjectOCMMockAdditionsTests
+
+- (void)testMock
+{
+    OCClassMockObject *mockStr = [NSString mock];
+
+    XCTAssertEqualObjects(@"OCMockObject[NSString]", [mockStr description], @"Should have received a mock of type OCClassMockObject and class NSString");
+}
+
+- (void)testNiceMock
+{
+    OCClassMockObject *mockStr = [NSString niceMock];
+
+    XCTAssertEqualObjects(@"OCMockObject[NSString]", [mockStr description], @"Should have received a mock of type OCClassMockObject and class NSString");
+    BOOL isNice;
+    object_getInstanceVariable(mockStr, "isNice", (void*)&isNice);
+    XCTAssertTrue(isNice, @"Expected mock to be nice");
+}
+
+- (void)testPartialMock
+{
+    OCPartialMockObject *mockStr = [NSString partialMock];
+    
+    XCTAssertEqualObjects(@"OCPartialMockObject[__NSCFConstantString]", [mockStr description], @"Should have received a mock of type OCPartialMockObject and class NSString");
+}
+
+@end

--- a/Source/OCMockTests/NSObjectOCMMockAdditionsTests.m
+++ b/Source/OCMockTests/NSObjectOCMMockAdditionsTests.m
@@ -25,7 +25,7 @@
     XCTAssertEqualObjects(@"OCMockObject[NSString]", [mockStr description], @"Should have received a mock of type OCClassMockObject and class NSString");
     BOOL isNice;
     object_getInstanceVariable(mockStr, "isNice", (void*)&isNice);
-    XCTAssertTrue(isNice, @"Expected mock to be nice");
+    XCTAssertTrue(isNice, @"Should have received a nice mock");
 }
 
 - (void)testPartialMock


### PR DESCRIPTION
Makes mocking objects a little smoother.

``` objective-c
// Instead of
[OCMockObject mockObjectForClass:[NSString class]
// or
OCMStrictClassMock([NSString class])
// You'd just do
[NSString mock]
```

:boar::train::train::train::train:
