### PR TITLE
Adding variable name to the block declaration

### DIFF
--- a/Source/OCMock/OCMockRecorder.h
+++ b/Source/OCMock/OCMockRecorder.h
@@ -25,7 +25,7 @@
 - (id)andThrow:(NSException *)anException;
 - (id)andPost:(NSNotification *)aNotification;
 - (id)andCall:(SEL)selector onObject:(id)anObject;
-- (id)andDo:(void (^)(NSInvocation *))block;
+- (id)andDo:(void (^)(NSInvocation *invocation))block;
 - (id)andForwardToRealObject;
 
 - (id)classMethod;


### PR DESCRIPTION
Simple fix on the public declaration of andDo method to support Xcode block autocompletion. 
Example of the problem below:

![xcode_autocompletion_error](https://cloud.githubusercontent.com/assets/625584/2979050/5e1e90e0-dbc4-11e3-8417-748d9f611322.gif)
