### PR TITLE
Support for converting between NSNumber/NSValue types for boxed return values

### DIFF
--- a/Source/OCMock/OCMBoxedReturnValueProvider.m
+++ b/Source/OCMock/OCMBoxedReturnValueProvider.m
@@ -8,17 +8,112 @@
 
 @implementation OCMBoxedReturnValueProvider
 
+static CFNumberType OCMNumberTypeForObjCType(const char *objcType)
+{
+    switch (objcType[0])
+    {
+        case 'c': return kCFNumberCharType;
+        case 'C': return kCFNumberCharType;
+        case 'B': return kCFNumberCharType;
+        case 's': return kCFNumberShortType;
+        case 'S': return kCFNumberShortType;
+        case 'i': return kCFNumberIntType;
+        case 'I': return kCFNumberIntType;
+        case 'l': return kCFNumberLongType;
+        case 'L': return kCFNumberLongType;
+        case 'q': return kCFNumberLongLongType;
+        case 'Q': return kCFNumberLongLongType;
+        case 'f': return kCFNumberFloatType;
+        case 'd': return kCFNumberDoubleType;
+    }
+    
+    return 0;
+}
+
+static NSNumber *OCMNumberForValue(NSValue *value)
+{
+#define CREATE_NUM(_type, _meth) ({ _type _v; [value getValue:&_v]; [NSNumber _meth _v]; })
+    switch ([value objCType][0])
+    {
+        case 'c': return CREATE_NUM(char,               numberWithChar:);
+        case 'C': return CREATE_NUM(unsigned char,      numberWithUnsignedChar:);
+        case 'B': return CREATE_NUM(bool,               numberWithBool:);
+        case 's': return CREATE_NUM(short,              numberWithShort:);
+        case 'S': return CREATE_NUM(unsigned short,     numberWithUnsignedShort:);
+        case 'i': return CREATE_NUM(int,                numberWithInt:);
+        case 'I': return CREATE_NUM(unsigned int,       numberWithUnsignedInt:);
+        case 'l': return CREATE_NUM(long,               numberWithLong:);
+        case 'L': return CREATE_NUM(unsigned long,      numberWithUnsignedLong:);
+        case 'q': return CREATE_NUM(long long,          numberWithLongLong:);
+        case 'Q': return CREATE_NUM(unsigned long long, numberWithUnsignedLongLong:);
+        case 'f': return CREATE_NUM(float,              numberWithFloat:);
+        case 'd': return CREATE_NUM(double,             numberWithDouble:);
+    }
+    
+    return nil;
+}
+
+static BOOL OCMGetOutputValue(NSValue *inputValue, const char *targetType, void *outputBuf)
+{
+    /* If the types match exactly, use it */
+    if (strcmp(targetType, [inputValue objCType]) == 0)
+    {
+        [inputValue getValue:outputBuf];
+        return YES;
+    }
+
+    /*
+     * See if they are similar number types, and if we can convert losslessly between them.
+     * For the most part, we set things up to use CFNumberGetValue, which returns false if
+     * conversion will be lossy.
+     */
+    CFNumberType inputType = OCMNumberTypeForObjCType([inputValue objCType]);
+    CFNumberType outputType = OCMNumberTypeForObjCType(targetType);
+    
+    if (inputType == 0 || outputType == 0) // one or both are non-number types
+        return NO;
+    
+
+    NSNumber *inputNumber = [inputValue isKindOfClass:[NSNumber class]]? (id)inputValue : OCMNumberForValue(inputValue);
+    
+    /*
+     * Due to some legacy, back-compatible requirements in CFNumber.c, CFNumberGetValue can return true for
+     * some conversions which should not be allowed (by reading source, conversions from integer types to
+     * 8-bit or 16-bit integer types).  So, check ourselves.
+     */
+    long long min = LLONG_MIN;
+    long long max = LLONG_MAX;
+    long long val = [inputNumber longLongValue];
+    switch (targetType[0])
+    {
+        case 'B':
+        case 'c': min = CHAR_MIN; max =  CHAR_MAX; break;
+        case 'C': min =        0; max = UCHAR_MAX; break;
+        case 's': min = SHRT_MIN; max =  SHRT_MAX; break;
+        case 'S': min =        0; max = USHRT_MAX; break;
+    }
+    if (val < min || val > max)
+        return NO;
+
+    /* Get the number, and return NO if the value was out of range or conversion was lossy */
+    return CFNumberGetValue((CFNumberRef)inputNumber, outputType, outputBuf);
+}
+
 - (void)handleInvocation:(NSInvocation *)anInvocation
 {
 	const char *returnType = [[anInvocation methodSignature] methodReturnType];
-	const char *valueType = [(NSValue *)returnValue objCType];
-	/* ARM64 uses 'B' for BOOLs in method signatures but 'c' in NSValue; that case should match */
-	if((strcmp(returnType, valueType) != 0) && !(returnType[0] == 'B' && valueType[0] == 'c'))
-		@throw [NSException exceptionWithName:NSInvalidArgumentException reason:[NSString stringWithFormat:@"Return value does not match method signature; signature declares '%s' but value is '%s'.", returnType, valueType] userInfo:nil];
-	void *buffer = malloc([[anInvocation methodSignature] methodReturnLength]);
-	[returnValue getValue:buffer];
-	[anInvocation setReturnValue:buffer];
-	free(buffer);
+    NSUInteger returnTypeSize = [[anInvocation methodSignature] methodReturnLength];
+    char valueBuffer[returnTypeSize];
+    NSValue *value = (NSValue *)returnValue;
+    
+    if (OCMGetOutputValue(value, returnType, valueBuffer))
+    {
+        [anInvocation setReturnValue:valueBuffer];
+    }
+    else
+    {
+        @throw [NSException exceptionWithName:NSInvalidArgumentException reason:[NSString stringWithFormat:@"Return value does not match method signature; signature declares '%s' but value is '%s'.", returnType, [value objCType]] userInfo:nil];
+    }
 }
 
 @end

--- a/Source/OCMockTests/OCMockObjectTests.m
+++ b/Source/OCMockTests/OCMockObjectTests.m
@@ -351,9 +351,59 @@ static NSString *TestNotification = @"TestNotification";
 	XCTAssertEqual(42, returnValue, @"Should have returned stubbed value.");
 }
 
+- (void)testReturnsStubbedUnsignedLongReturnValue
+{
+    mock = [OCMockObject mockForClass:[NSNumber class]];
+    [[[mock expect] andReturnValue:@42LU] unsignedLongValue];
+    unsigned long returnValue = [mock unsignedLongValue];
+    XCTAssertEqual(returnValue, 42LU, @"Should have returned stubbed value.");
+
+    [[[mock expect] andReturnValue:@42] unsignedLongValue];
+    returnValue = [mock unsignedLongValue];
+    XCTAssertEqual(returnValue, 42LU, @"Should have returned stubbed value.");
+
+    [[[mock expect] andReturnValue:@42.0] unsignedLongValue];
+    returnValue = [mock unsignedLongValue];
+    XCTAssertEqual(returnValue, 42LU, @"Should have returned stubbed value.");
+
+    [[[mock expect] andReturnValue:OCMOCK_VALUE((char)42)] unsignedLongValue];
+    returnValue = [mock unsignedLongValue];
+    XCTAssertEqual(returnValue, 42LU, @"Should have returned stubbed value.");
+
+    [[[mock expect] andReturnValue:OCMOCK_VALUE((float)42)] unsignedLongValue];
+    returnValue = [mock unsignedLongValue];
+    XCTAssertEqual(returnValue, 42LU, @"Should have returned stubbed value.");
+
+    [[[mock expect] andReturnValue:OCMOCK_VALUE((float)42.5)] unsignedLongValue];
+    XCTAssertThrows([mock unsignedLongValue], @"Should not be able to convert non-integer float to long");
+
+#if !__LP64__
+    [[[mock expect] andReturnValue:OCMOCK_VALUE((long long)LLONG_MAX)] unsignedLongValue];
+    XCTAssertThrows([mock unsignedLongValue], @"Should not be able to convert large long long to long");
+#endif
+}
+
+- (void)testReturnsStubbedBoolReturnValue
+{
+    [[[mock expect] andReturnValue:@YES] boolValue];
+    BOOL returnValue = [mock boolValue];
+    XCTAssertEqual(returnValue, YES, @"Should have returned stubbed value.");
+
+    [[[mock expect] andReturnValue:OCMOCK_VALUE(YES)] boolValue];
+    returnValue = [mock boolValue];
+    XCTAssertEqual(returnValue, YES, @"Should have returned stubbed value.");
+
+    [[[mock expect] andReturnValue:OCMOCK_VALUE(1)] boolValue];
+    returnValue = [mock boolValue];
+    XCTAssertEqual(returnValue, YES, @"Should have returned stubbed value.");
+
+    [[[mock expect] andReturnValue:OCMOCK_VALUE(300)] boolValue];
+    XCTAssertThrows([mock boolValue], @"Should not be able to convert large integer into BOOL");
+}
+
 - (void)testRaisesWhenBoxedValueTypesDoNotMatch
 {
-	[[[mock stub] andReturnValue:@42.0] intValue];
+	[[[mock stub] andReturnValue:[NSValue valueWithRange:NSMakeRange(0, 0)]] intValue];
 
 	XCTAssertThrows([mock intValue], @"Should have raised an exception.");
 }


### PR DESCRIPTION
Implement support for converting between NSNumber/NSValue types, but raise if the conversion is lossy (values out of range, non-whole-number float values to integers, etc.).

 Solves a number of problems with different BOOL types ('c' vs 'B') and method signature vs NSValue types which can differ a little in different architectures.

This is using the approach I outlined in the comments to #58 but with a couple of additional range checks which Apple seems to intentionally allow for back-compatibility reasons.

The unit tests passed when tested against OCMock 2.x.  This is converted to merge against master, and should compile, but I get infinite recursion when running unit tests on the master branch right now so I can't verify they pass there.
