### PR TITLE
Adds check for nil before calling blocks.

### DIFF
--- a/Source/OCMock/OCMBlockCaller.m
+++ b/Source/OCMock/OCMBlockCaller.m
@@ -34,7 +34,10 @@
 
 - (void)handleInvocation:(NSInvocation *)anInvocation
 {
-	block(anInvocation);
+    if (block != nil)
+    {
+        block(anInvocation);
+    }
 }
 
 @end


### PR DESCRIPTION
 This allows for partial mocks to stub out methods to literally do nothing (instead of their non-stubbed behavior).
