### PR TITLE
Changing time stamp to random number.

### DIFF
--- a/Source/OCMock/OCMFunctions.m
+++ b/Source/OCMock/OCMFunctions.m
@@ -65,8 +65,7 @@ const char *OCMTypeWithoutQualifiers(const char *objCType)
 
 Class OCMCreateSubclass(Class class, void *ref)
 {
-    double timestamp = [NSDate timeIntervalSinceReferenceDate];
-    const char *className = [[NSString stringWithFormat:@"%@-%p-%f", NSStringFromClass(class), ref, timestamp] UTF8String];
+    const char *className = [[NSString stringWithFormat:@"%@-%p-%u", NSStringFromClass(class), ref, arc4random()] UTF8String];
     Class subclass = objc_allocateClassPair(class, className, 0);
     objc_registerClassPair(subclass);
     return subclass;


### PR DESCRIPTION
For some of our tests, we have to mock NSDate to get consistent results. However, this doesn't play nicely with OCMock. Changing the timestamp to a random number prevents the class names from colliding, while still working if NSDate happens to be mocked.
