### PR TITLE
@erikdoe => add OCMock podspec - closes #88

### DIFF
--- a/OCMock.podspec
+++ b/OCMock.podspec
@@ -1,0 +1,28 @@
+Pod::Spec.new do |s|
+  s.name         = "OCMock"
+  s.version      = "3.0"
+  
+  s.summary      = "Mock objects for Objective-C"
+  s.description      = <<-DESC
+                        OCMock is an Objective-C implementation of mock objects. It provides
+                        stubs that return pre-determined values for specific method invocations,
+                        dynamic mocks that can be used to verify interaction patterns, and
+                        partial mocks to overwrite selected methods of existing objects.
+                        DESC
+  
+  s.homepage     = "http://ocmock.org"
+  s.license      = { :type => "Apache 2.0", :file => "Source/License.txt" }
+
+  s.author             = { "Erik Doernenburg" => "erik@doernenburg.com" }
+  s.social_media_url   = "http://twitter.com/erikdoe"
+  
+  s.source       = { :git => "https://github.com/erikdoe/ocmock.git", :tag => "v3.0" }
+  s.source_files  = "Source", "Source/**/*.{h,m}"
+  
+  s.public_header_files = ["OCMock.h", "OCMockObject.h", "OCMockRecorder.h", "OCMArg.h", "OCMConstraint.h", "OCMLocation.h", "OCMMacroState.h", "NSNotificationCenter+OCMAdditions.h"].map { |file|
+    "Source/" + file
+  }
+  
+  s.framework = "XCTest"
+  s.requires_arc = false
+end


### PR DESCRIPTION
This needs to be in the root folder of your project, so CocoaPods can clone the repo and look for it with the known name. Everything seems to be linting fine locally with `pod spec lint`. 

Should just be a matter of going through the trunk registration and adding it. You may need to [claim this pod](http://trunk.cocoapods.org/) too.
