### PR TITLE
Exclude Tests From the pod spec

### DIFF
--- a/OCMock.podspec
+++ b/OCMock.podspec
@@ -17,8 +17,7 @@ Pod::Spec.new do |s|
   s.social_media_url   = "http://twitter.com/erikdoe"
   
   s.source       = { :git => "https://github.com/erikdoe/ocmock.git", :tag => "v3.0" }
-  s.source_files  = "Source", "Source/**/*.{h,m}"
-  s.exclude_files = "Source/OCMockTests/*.{h,m}, Source/OCMockLibTests/*.{h,m}"
+  s.source_files  = "Source/OCMock/**/*.{h,m}"
   
   s.public_header_files = ["OCMock.h", "OCMockObject.h", "OCMockRecorder.h", "OCMArg.h", "OCMConstraint.h", "OCMLocation.h", "OCMMacroState.h", "NSNotificationCenter+OCMAdditions.h"].map { |file|
     "Source/" + file


### PR DESCRIPTION
Hi,

I've tried the new pod spec for 3.0. It works great except that the test case classes are include in the source files description in the pod spec. This will cause xcode to list and execute all the OCMock tests together with my own test.

I have updated the podspec file to only include the relevant source files.

I think you have to do a new commit to cocoa pods with this pod spec file.
