### PR TITLE
erikdoe => fixes for podspec

### DIFF
--- a/OCMock.podspec
+++ b/OCMock.podspec
@@ -17,10 +17,10 @@ Pod::Spec.new do |s|
   s.social_media_url   = "http://twitter.com/erikdoe"
   
   s.source       = { :git => "https://github.com/erikdoe/ocmock.git", :tag => "v3.0" }
-  s.source_files  = "Source", "Source/**/*.{h,m}"
+  s.source_files  = "Source/OCMock/*.{h,m}"
   
   s.public_header_files = ["OCMock.h", "OCMockObject.h", "OCMockRecorder.h", "OCMArg.h", "OCMConstraint.h", "OCMLocation.h", "OCMMacroState.h", "NSNotificationCenter+OCMAdditions.h"].map { |file|
-    "Source/" + file
+    "Source/OCMock/" + file
   }
   
   s.framework = "XCTest"


### PR DESCRIPTION
You don't have to do anything outside of this PR, as I've applied the same fixes to CocoaPods myself. The original Podspec worked but was a tad liberal in it's file globbing. It would also take in the OCMock tests to the user's project. This now doesn't do that and correctly set the publicity of the public header files :+1: 

![screen shot 2014-06-26 at 9 31 25 am](https://cloud.githubusercontent.com/assets/49038/3398949/8a934d26-fd36-11e3-83b0-0d279557cf72.png)

works nicely :+1: - I'm excited to start porting my app tests over.
