### PR TITLE
Silence warning "'NSProxy' may not respond to 'doesNotRecognizeSelector:...

### DIFF
--- a/Source/OCMock/OCMockObject.m
+++ b/Source/OCMock/OCMockObject.m
@@ -27,6 +27,11 @@
 #import "OCMFunctions.h"
 #import "OCMVerifier.h"
 
+@interface NSProxy ()
+
+- (void)doesNotRecognizeSelector:(SEL)aSelector;
+
+@end
 
 @implementation OCMockObject
 


### PR DESCRIPTION
Although NSProxy implements -doesNotRecognizeSelector:, it does not declare that it does so in any header. NSProxy is a root class which implements the NSObject protocol, but -doesNotRecognizeSelector: is not a part of that protocol. Rather, it's defined as a method on the NSObject class, which NSProxy does not inherit from.

NSProxy's implementation of -doesNotRecognizeSelector: just throws an exception, meaning it is a programmer error to call -doesNotRecognizeSelector: on NSProxy. Therefore, it makes sense that this method is not declared in NSProxy's header. It's better for the compiler to throw a warning than for an an exception to be thrown at runtime.

However, in this case, we want to trigger the exception, so it's appropriate to call -doesNotRecognizeSelector:.
