### PR TITLE
Silence warnings when passing invocations

### DIFF
--- a/Source/OCMock/OCMock.h
+++ b/Source/OCMock/OCMock.h
@@ -39,21 +39,27 @@
 
 #define OCMStub(invocation) \
 ({ \
-    [OCMMacroState beginStubMacro]; \
-    invocation; \
-    [OCMMacroState endStubMacro]; \
+    _OCMSilenceWarnings( \
+        [OCMMacroState beginStubMacro]; \
+        invocation; \
+        [OCMMacroState endStubMacro]; \
+    ); \
 })
 
 #define OCMExpect(invocation) \
 ({ \
-    [OCMMacroState beginExpectMacro]; \
-    invocation; \
-    [OCMMacroState endExpectMacro]; \
+    _OCMSilenceWarnings( \
+        [OCMMacroState beginExpectMacro]; \
+        invocation; \
+        [OCMMacroState endExpectMacro]; \
+    ); \
 })
 
 #define ClassMethod(invocation) \
-    [[OCMMacroState globalState] switchToClassMethod]; \
-    invocation;
+    _OCMSilenceWarnings( \
+        [[OCMMacroState globalState] switchToClassMethod]; \
+        invocation; \
+    );
 
 
 #define OCMVerifyAll(mock) [mock verifyAtLocation:OCMMakeLocation(self, __FILE__, __LINE__)]
@@ -62,7 +68,17 @@
 
 #define OCMVerify(invocation) \
 ({ \
-    [OCMMacroState beginVerifyMacroAtLocation:OCMMakeLocation(self, __FILE__, __LINE__)]; \
-    invocation; \
-    [OCMMacroState endVerifyMacro]; \
+    _OCMSilenceWarnings( \
+        [OCMMacroState beginVerifyMacroAtLocation:OCMMakeLocation(self, __FILE__, __LINE__)]; \
+        invocation; \
+        [OCMMacroState endVerifyMacro]; \
+    ); \
+})
+
+#define _OCMSilenceWarnings(macro) \
+({ \
+    _Pragma("clang diagnostic push") \
+    _Pragma("clang diagnostic ignored \"-Wunused-value\"") \
+    macro \
+    _Pragma("clang diagnostic pop") \
 })


### PR DESCRIPTION
When passing invocations that return values, you can end up with compiler
warnings that you're not using the result (for example, when verifying that an
`init` method is called). This isn't ideal, and leads to having to add ugly
`#pragma clang` definitions in your test file. Instead, we can use the C99
`_Pragma()` function to disable these warnings inside the macros themselves.
