### PR TITLE
Tweaks to allow running on MacOS X 10.8

### DIFF
--- a/Source/OCMock/NSObject+OCMAdditions.m
+++ b/Source/OCMock/NSObject+OCMAdditions.m
@@ -28,10 +28,10 @@
 #ifndef __arm64__
     NSMethodSignature *sig = [self instanceMethodSignatureForSelector:aSelector];
     if([sig usesSpecialStructureReturn])
-        return class_getMethodImplementation_stret(self, selectorWithNoImplementation);
+        return class_getMethodImplementation_stret([NSObject class], selectorWithNoImplementation);
 #endif
     
-    return class_getMethodImplementation(self, selectorWithNoImplementation);
+    return class_getMethodImplementation([NSObject class], selectorWithNoImplementation);
 }
 
 

--- a/Source/OCMock/OCClassMockObject.m
+++ b/Source/OCMock/OCClassMockObject.m
@@ -93,7 +93,7 @@
     class_addMethod(newMetaClass, @selector(forwardInvocation:), myForwardIMP, method_getTypeEncoding(myForwardMethod));
 
     /* adding forwarder for all class methods (instance methods on meta class) to allow for verify after run */
-    NSArray *whiteList = @[@"class", @"forwardingTargetForSelector:", @"methodSignatureForSelector:", @"forwardInvocation:"];
+    NSArray *whiteList = @[@"class", @"forwardingTargetForSelector:", @"methodSignatureForSelector:", @"forwardInvocation:", @"isBlock"];
     [NSObject enumerateMethodsInClass:originalMetaClass usingBlock:^(SEL selector) {
             if(![whiteList containsObject:NSStringFromSelector(selector)])
                 [self setupForwarderForClassMethodSelector:selector];

--- a/Source/OCMock/OCPartialMockObject.m
+++ b/Source/OCMock/OCPartialMockObject.m
@@ -117,7 +117,7 @@
 
     /* Adding forwarder for all instance methods to allow for verify after run */
     NSArray *whiteList = @[@"class", @"forwardingTargetForSelector:", @"methodSignatureForSelector:", @"forwardInvocation:",
-            @"allowsWeakReference", @"_isDeallocating", @"retainWeakReference", @"_tryRetain"];
+            @"allowsWeakReference", @"_isDeallocating", @"retainWeakReference", @"_tryRetain", @"isBlock"];
     [NSObject enumerateMethodsInClass:mockedClass usingBlock:^(SEL selector) {
         if(![whiteList containsObject:NSStringFromSelector(selector)])
             [self setupForwarderForSelector:selector];


### PR DESCRIPTION
I have not been able to run any of the OCMock3 test cases on MacOS X 10.8 (Mountain Lion).  I get infinite recursion in a few places, so the tests crash out.  I believe this is the issue in #107.  I can run in the IOS7 simulator, but not the OSX side.  Being XCTest, we can no longer test on iOS6 so I don't know if that also has an older runtime which OCMock has issues with.

After a few stabs, I think I came up with some simple tweaks which allow things to work for me again.

The first one is using [NSObject class] directly avoids the chance we are using a class which has had all its methods mocked out when obtaining the objc_msgForward function, which seemed to be an issue.  Without that, the runtime seems to call a mocked-out method repeatedly.  Also added "isBlock" to the white lists, since some internal calls to that would also infinitely recurse.  With these changes, all the tests pass cleanly when running on 10.8, which none of the OCMock3 versions had for me.
