### PR TITLE
Use instancetype instead of id for initializers

### DIFF
--- a/Source/OCMock/OCMConstraint.h
+++ b/Source/OCMock/OCMConstraint.h
@@ -19,15 +19,15 @@
 
 @interface OCMConstraint : NSObject 
 
-+ (id)constraint;
++ (instancetype)constraint;
 - (BOOL)evaluate:(id)value;
 
 // if you are looking for any, isNil, etc, they have moved to OCMArg
 
 // try to use [OCMArg checkWith...] instead of the constraintWith... methods below
 
-+ (id)constraintWithSelector:(SEL)aSelector onObject:(id)anObject;
-+ (id)constraintWithSelector:(SEL)aSelector onObject:(id)anObject withValue:(id)aValue;
++ (instancetype)constraintWithSelector:(SEL)aSelector onObject:(id)anObject;
++ (instancetype)constraintWithSelector:(SEL)aSelector onObject:(id)anObject withValue:(id)aValue;
 
 
 @end
@@ -62,7 +62,7 @@
 	BOOL (^block)(id);
 }
 
-- (id)initWithConstraintBlock:(BOOL (^)(id))block;
+- (instancetype)initWithConstraintBlock:(BOOL (^)(id))block;
 
 @end
 

--- a/Source/OCMock/OCMConstraint.m
+++ b/Source/OCMock/OCMConstraint.m
@@ -19,7 +19,7 @@
 
 @implementation OCMConstraint
 
-+ (id)constraint
++ (instancetype)constraint
 {
 	return [[[self alloc] init] autorelease];
 }
@@ -34,7 +34,7 @@
     return [self retain];
 }
 
-+ (id)constraintWithSelector:(SEL)aSelector onObject:(id)anObject
++ (instancetype)constraintWithSelector:(SEL)aSelector onObject:(id)anObject
 {
 	OCMInvocationConstraint *constraint = [OCMInvocationConstraint constraint];
 	NSMethodSignature *signature = [anObject methodSignatureForSelector:aSelector]; 
@@ -47,7 +47,7 @@
 	return constraint;
 }
 
-+ (id)constraintWithSelector:(SEL)aSelector onObject:(id)anObject withValue:(id)aValue
++ (instancetype)constraintWithSelector:(SEL)aSelector onObject:(id)anObject withValue:(id)aValue
 {
 	OCMInvocationConstraint *constraint = [self constraintWithSelector:aSelector onObject:anObject];
 	if([[constraint->invocation methodSignature] numberOfArguments] < 4)
@@ -132,7 +132,7 @@
 
 @implementation OCMBlockConstraint
 
-- (id)initWithConstraintBlock:(BOOL (^)(id))aBlock
+- (instancetype)initWithConstraintBlock:(BOOL (^)(id))aBlock
 {
 	self = [super init];
 	block = [aBlock copy];

--- a/Source/OCMock/OCMLocation.h
+++ b/Source/OCMock/OCMLocation.h
@@ -23,9 +23,9 @@
     NSUInteger  line;
 }
 
-+ (id)locationWithTestCase:(id)aTestCase file:(NSString *)aFile line:(NSUInteger)aLine;
++ (instancetype)locationWithTestCase:(id)aTestCase file:(NSString *)aFile line:(NSUInteger)aLine;
 
-- (id)initWithTestCase:(id)aTestCase file:(NSString *)aFile line:(NSUInteger)aLine;
+- (instancetype)initWithTestCase:(id)aTestCase file:(NSString *)aFile line:(NSUInteger)aLine;
 
 - (id)testCase;
 - (NSString *)file;

--- a/Source/OCMock/OCMLocation.m
+++ b/Source/OCMock/OCMLocation.m
@@ -18,12 +18,12 @@
 
 @implementation OCMLocation
 
-+ (id)locationWithTestCase:(id)aTestCase file:(NSString *)aFile line:(NSUInteger)aLine
++ (instancetype)locationWithTestCase:(id)aTestCase file:(NSString *)aFile line:(NSUInteger)aLine
 {
     return [[[OCMLocation alloc] initWithTestCase:aTestCase file:aFile line:aLine] autorelease];
 }
 
-- (id)initWithTestCase:(id)aTestCase file:(NSString *)aFile line:(NSUInteger)aLine
+- (instancetype)initWithTestCase:(id)aTestCase file:(NSString *)aFile line:(NSUInteger)aLine
 {
     self = [super init];
     testCase = aTestCase;

--- a/Source/OCMock/OCMRecorder.h
+++ b/Source/OCMock/OCMRecorder.h
@@ -26,8 +26,8 @@
     OCMInvocationMatcher *invocationMatcher;
 }
 
-- (id)init;
-- (id)initWithMockObject:(OCMockObject *)aMockObject;
+- (instancetype)init;
+- (instancetype)initWithMockObject:(OCMockObject *)aMockObject;
 
 - (void)setMockObject:(OCMockObject *)aMockObject;
 

--- a/Source/OCMock/OCMRecorder.m
+++ b/Source/OCMock/OCMRecorder.m
@@ -22,13 +22,13 @@
 
 @implementation OCMRecorder
 
-- (id)init
+- (instancetype)init
 {
     // no super, we're inheriting from NSProxy
     return self;
 }
 
-- (id)initWithMockObject:(OCMockObject *)aMockObject
+- (instancetype)initWithMockObject:(OCMockObject *)aMockObject
 {
     [self init];
     [self setMockObject:aMockObject];

--- a/Source/OCMock/OCMReturnValueProvider.h
+++ b/Source/OCMock/OCMReturnValueProvider.h
@@ -21,7 +21,7 @@
 	id	returnValue;
 }
 
-- (id)initWithValue:(id)aValue;
+- (instancetype)initWithValue:(id)aValue;
 
 - (void)handleInvocation:(NSInvocation *)anInvocation;
 

--- a/Source/OCMock/OCMReturnValueProvider.m
+++ b/Source/OCMock/OCMReturnValueProvider.m
@@ -21,7 +21,7 @@
 
 @implementation OCMReturnValueProvider
 
-- (id)initWithValue:(id)aValue
+- (instancetype)initWithValue:(id)aValue
 {
 	self = [super init];
 	returnValue = [aValue retain];

--- a/Source/OCMock/OCMockObject.h
+++ b/Source/OCMock/OCMockObject.h
@@ -42,7 +42,7 @@
 
 + (id)observerMock;
 
-- (id)init;
+- (instancetype)init;
 
 - (void)setExpectationOrderMatters:(BOOL)flag;
 

--- a/Source/OCMock/OCMockObject.m
+++ b/Source/OCMock/OCMockObject.m
@@ -85,7 +85,7 @@
 
 #pragma mark  Initialisers, description, accessors, etc.
 
-- (id)init
+- (instancetype)init
 {
 	// no [super init], we're inheriting from NSProxy
 	expectationOrderMatters = NO;


### PR DESCRIPTION
Switch to `instancetype` instead of `id` so that the compiler has more information with regard to type safety.
