### PR TITLE
Fix for clang static analyzer issue CWE-119

### DIFF
--- a/Source/OCMock/NSInvocation+OCMAdditions.m
+++ b/Source/OCMock/NSInvocation+OCMAdditions.m
@@ -364,8 +364,8 @@
 	char *cStringPtr;
 	
 	[self getArgument:&cStringPtr atIndex:anInt];
-	strncpy(buffer, cStringPtr, 100);
-    strcpy(buffer + 100, "...");
+    	strlcpy(buffer, cStringPtr, sizeof(buffer));
+    	strlcpy(buffer + 100, "...", sizeof(buffer));
 	return [NSString stringWithFormat:@"\"%s\"", buffer];
 }
 

--- a/Source/OCMock/NSInvocation+OCMAdditions.m
+++ b/Source/OCMock/NSInvocation+OCMAdditions.m
@@ -364,8 +364,8 @@
 	char *cStringPtr;
 	
 	[self getArgument:&cStringPtr atIndex:anInt];
-    	strlcpy(buffer, cStringPtr, sizeof(buffer));
-    	strlcpy(buffer + 100, "...", sizeof(buffer));
+	strlcpy(buffer, cStringPtr, sizeof(buffer));
+	strlcpy(buffer + 100, "...", (sizeof(buffer) - 100));
 	return [NSString stringWithFormat:@"\"%s\"", buffer];
 }
 


### PR DESCRIPTION
Switch to `strlcpy` since it is safer to use and remove `strcpy` since it is insecure (although I don't know why unit test code would try to manipulate the buffer, but better safe than sorry).