### PR TITLE
Use NSInteger instead of int for 32/64 bit safety

### DIFF
--- a/Source/OCMock/NSInvocation+OCMAdditions.h
+++ b/Source/OCMock/NSInvocation+OCMAdditions.h
@@ -20,28 +20,28 @@
 
 - (BOOL)hasCharPointerArgument;
 
-- (id)getArgumentAtIndexAsObject:(int)argIndex;
+- (id)getArgumentAtIndexAsObject:(NSInteger)argIndex;
 
 - (NSString *)invocationDescription;
 
-- (NSString *)argumentDescriptionAtIndex:(int)argIndex;
+- (NSString *)argumentDescriptionAtIndex:(NSInteger)argIndex;
 
-- (NSString *)objectDescriptionAtIndex:(int)anInt;
-- (NSString *)charDescriptionAtIndex:(int)anInt;
-- (NSString *)unsignedCharDescriptionAtIndex:(int)anInt;
-- (NSString *)intDescriptionAtIndex:(int)anInt;
-- (NSString *)unsignedIntDescriptionAtIndex:(int)anInt;
-- (NSString *)shortDescriptionAtIndex:(int)anInt;
-- (NSString *)unsignedShortDescriptionAtIndex:(int)anInt;
-- (NSString *)longDescriptionAtIndex:(int)anInt;
-- (NSString *)unsignedLongDescriptionAtIndex:(int)anInt;
-- (NSString *)longLongDescriptionAtIndex:(int)anInt;
-- (NSString *)unsignedLongLongDescriptionAtIndex:(int)anInt;
-- (NSString *)doubleDescriptionAtIndex:(int)anInt;
-- (NSString *)floatDescriptionAtIndex:(int)anInt;
-- (NSString *)structDescriptionAtIndex:(int)anInt;
-- (NSString *)pointerDescriptionAtIndex:(int)anInt;
-- (NSString *)cStringDescriptionAtIndex:(int)anInt;
-- (NSString *)selectorDescriptionAtIndex:(int)anInt;
+- (NSString *)objectDescriptionAtIndex:(NSInteger)anInt;
+- (NSString *)charDescriptionAtIndex:(NSInteger)anInt;
+- (NSString *)unsignedCharDescriptionAtIndex:(NSInteger)anInt;
+- (NSString *)intDescriptionAtIndex:(NSInteger)anInt;
+- (NSString *)unsignedIntDescriptionAtIndex:(NSInteger)anInt;
+- (NSString *)shortDescriptionAtIndex:(NSInteger)anInt;
+- (NSString *)unsignedShortDescriptionAtIndex:(NSInteger)anInt;
+- (NSString *)longDescriptionAtIndex:(NSInteger)anInt;
+- (NSString *)unsignedLongDescriptionAtIndex:(NSInteger)anInt;
+- (NSString *)longLongDescriptionAtIndex:(NSInteger)anInt;
+- (NSString *)unsignedLongLongDescriptionAtIndex:(NSInteger)anInt;
+- (NSString *)doubleDescriptionAtIndex:(NSInteger)anInt;
+- (NSString *)floatDescriptionAtIndex:(NSInteger)anInt;
+- (NSString *)structDescriptionAtIndex:(NSInteger)anInt;
+- (NSString *)pointerDescriptionAtIndex:(NSInteger)anInt;
+- (NSString *)cStringDescriptionAtIndex:(NSInteger)anInt;
+- (NSString *)selectorDescriptionAtIndex:(NSInteger)anInt;
 
 @end

--- a/Source/OCMock/NSInvocation+OCMAdditions.m
+++ b/Source/OCMock/NSInvocation+OCMAdditions.m
@@ -23,7 +23,7 @@
 - (BOOL)hasCharPointerArgument
 {
     NSMethodSignature *signature = [self methodSignature];
-    for(int i = 0; i < [signature numberOfArguments]; i++)
+    for(NSUInteger i = 0; i < [signature numberOfArguments]; i++)
     {
         const char *argType = OCMTypeWithoutQualifiers([signature getArgumentTypeAtIndex:i]);
         if(strcmp(argType, "*") == 0)
@@ -33,9 +33,9 @@
 }
 
 
-- (id)getArgumentAtIndexAsObject:(int)argIndex
+- (id)getArgumentAtIndexAsObject:(NSInteger)argIndex
 {
-	const char *argType = OCMTypeWithoutQualifiers([[self methodSignature] getArgumentTypeAtIndex:argIndex]);
+	const char *argType = OCMTypeWithoutQualifiers([[self methodSignature] getArgumentTypeAtIndex:(NSUInteger)argIndex]);
 
 	if((strlen(argType) > 1) && (strchr("{^", argType[0]) == NULL) && (strcmp("@?", argType) != 0))
 		[NSException raise:NSInvalidArgumentException format:@"Cannot handle argument type '%s'.", argType];
@@ -149,7 +149,7 @@
 		case '{': // structure
 		{
 			NSUInteger argSize;
-			NSGetSizeAndAlignment([[self methodSignature] getArgumentTypeAtIndex:argIndex], &argSize, NULL);
+			NSGetSizeAndAlignment([[self methodSignature] getArgumentTypeAtIndex:(NSUInteger)argIndex], &argSize, NULL);
 			if(argSize == 0) // TODO: Can this happen? Is frameLength a good choice in that case?
                 argSize = [[self methodSignature] frameLength];
 			NSMutableData *argumentData = [[[NSMutableData alloc] initWithLength:argSize] autorelease];
@@ -172,19 +172,19 @@
 	
 	NSArray *selectorParts = [NSStringFromSelector([self selector]) componentsSeparatedByString:@":"];
 	NSMutableString *description = [[NSMutableString alloc] init];
-	unsigned int i;
+	NSUInteger i;
 	for(i = 2; i < numberOfArgs; i++)
 	{
 		[description appendFormat:@"%@%@:", (i > 2 ? @" " : @""), [selectorParts objectAtIndex:(i - 2)]];
-		[description appendString:[self argumentDescriptionAtIndex:i]];
+		[description appendString:[self argumentDescriptionAtIndex:(NSInteger)i]];
 	}
 	
 	return [description autorelease];
 }
 
-- (NSString *)argumentDescriptionAtIndex:(int)argIndex
+- (NSString *)argumentDescriptionAtIndex:(NSInteger)argIndex
 {
-	const char *argType = OCMTypeWithoutQualifiers([[self methodSignature] getArgumentTypeAtIndex:argIndex]);
+	const char *argType = OCMTypeWithoutQualifiers([[self methodSignature] getArgumentTypeAtIndex:(NSUInteger)argIndex]);
 
 	switch(*argType)
 	{
@@ -213,7 +213,7 @@
 }
 
 
-- (NSString *)objectDescriptionAtIndex:(int)anInt
+- (NSString *)objectDescriptionAtIndex:(NSInteger)anInt
 {
 	id object;
 	
@@ -227,14 +227,14 @@
 		return [object description] ?: @"<nil description>";
 }
 
-- (NSString *)boolDescriptionAtIndex:(int)anInt
+- (NSString *)boolDescriptionAtIndex:(NSInteger)anInt
 {
 	bool value;
 	[self getArgument:&value atIndex:anInt];
 	return value? @"YES" : @"NO";
 }
 
-- (NSString *)charDescriptionAtIndex:(int)anInt
+- (NSString *)charDescriptionAtIndex:(NSInteger)anInt
 {
 	unsigned char buffer[128];
 	memset(buffer, 0x0, 128);
@@ -248,7 +248,7 @@
 		return [NSString stringWithFormat:@"'%c'", *buffer];
 }
 
-- (NSString *)unsignedCharDescriptionAtIndex:(int)anInt
+- (NSString *)unsignedCharDescriptionAtIndex:(NSInteger)anInt
 {
 	unsigned char buffer[128];
 	memset(buffer, 0x0, 128);
@@ -257,7 +257,7 @@
 	return [NSString stringWithFormat:@"'%c'", *buffer];
 }
 
-- (NSString *)intDescriptionAtIndex:(int)anInt
+- (NSString *)intDescriptionAtIndex:(NSInteger)anInt
 {
 	int intValue;
 	
@@ -265,7 +265,7 @@
 	return [NSString stringWithFormat:@"%d", intValue];
 }
 
-- (NSString *)unsignedIntDescriptionAtIndex:(int)anInt
+- (NSString *)unsignedIntDescriptionAtIndex:(NSInteger)anInt
 {
 	unsigned int intValue;
 	
@@ -273,7 +273,7 @@
 	return [NSString stringWithFormat:@"%d", intValue];
 }
 
-- (NSString *)shortDescriptionAtIndex:(int)anInt
+- (NSString *)shortDescriptionAtIndex:(NSInteger)anInt
 {
 	short shortValue;
 	
@@ -281,7 +281,7 @@
 	return [NSString stringWithFormat:@"%hi", shortValue];
 }
 
-- (NSString *)unsignedShortDescriptionAtIndex:(int)anInt
+- (NSString *)unsignedShortDescriptionAtIndex:(NSInteger)anInt
 {
 	unsigned short shortValue;
 	
@@ -289,7 +289,7 @@
 	return [NSString stringWithFormat:@"%hu", shortValue];
 }
 
-- (NSString *)longDescriptionAtIndex:(int)anInt
+- (NSString *)longDescriptionAtIndex:(NSInteger)anInt
 {
 	long longValue;
 	
@@ -297,7 +297,7 @@
 	return [NSString stringWithFormat:@"%ld", longValue];
 }
 
-- (NSString *)unsignedLongDescriptionAtIndex:(int)anInt
+- (NSString *)unsignedLongDescriptionAtIndex:(NSInteger)anInt
 {
 	unsigned long longValue;
 	
@@ -305,7 +305,7 @@
 	return [NSString stringWithFormat:@"%lu", longValue];
 }
 
-- (NSString *)longLongDescriptionAtIndex:(int)anInt
+- (NSString *)longLongDescriptionAtIndex:(NSInteger)anInt
 {
 	long long longLongValue;
 	
@@ -313,7 +313,7 @@
 	return [NSString stringWithFormat:@"%qi", longLongValue];
 }
 
-- (NSString *)unsignedLongLongDescriptionAtIndex:(int)anInt
+- (NSString *)unsignedLongLongDescriptionAtIndex:(NSInteger)anInt
 {
 	unsigned long long longLongValue;
 	
@@ -321,7 +321,7 @@
 	return [NSString stringWithFormat:@"%qu", longLongValue];
 }
 
-- (NSString *)doubleDescriptionAtIndex:(int)anInt
+- (NSString *)doubleDescriptionAtIndex:(NSInteger)anInt
 {
 	double doubleValue;
 	
@@ -329,7 +329,7 @@
 	return [NSString stringWithFormat:@"%f", doubleValue];
 }
 
-- (NSString *)floatDescriptionAtIndex:(int)anInt
+- (NSString *)floatDescriptionAtIndex:(NSInteger)anInt
 {
 	float floatValue;
 	
@@ -337,7 +337,7 @@
 	return [NSString stringWithFormat:@"%f", floatValue];
 }
 
-- (NSString *)longDoubleDescriptionAtIndex:(int)anInt
+- (NSString *)longDoubleDescriptionAtIndex:(NSInteger)anInt
 {
 	long double longDoubleValue;
 	
@@ -345,12 +345,12 @@
 	return [NSString stringWithFormat:@"%Lf", longDoubleValue];
 }
 
-- (NSString *)structDescriptionAtIndex:(int)anInt
+- (NSString *)structDescriptionAtIndex:(NSInteger)anInt
 {
     return [NSString stringWithFormat:@"(%@)", [[self getArgumentAtIndexAsObject:anInt] description]];
 }
 
-- (NSString *)pointerDescriptionAtIndex:(int)anInt
+- (NSString *)pointerDescriptionAtIndex:(NSInteger)anInt
 {
 	void *buffer;
 	
@@ -358,7 +358,7 @@
 	return [NSString stringWithFormat:@"%p", buffer];
 }
 
-- (NSString *)cStringDescriptionAtIndex:(int)anInt
+- (NSString *)cStringDescriptionAtIndex:(NSInteger)anInt
 {
 	char buffer[104];
 	char *cStringPtr;
@@ -369,7 +369,7 @@
 	return [NSString stringWithFormat:@"\"%s\"", buffer];
 }
 
-- (NSString *)selectorDescriptionAtIndex:(int)anInt
+- (NSString *)selectorDescriptionAtIndex:(NSInteger)anInt
 {
 	SEL selectorValue;
 	


### PR DESCRIPTION
Use `NSInteger` instead of the primitive int for better 32/64 bit compatibility. Also eliminates implicit conversions between `int`, `NSInteger`, and `NSUInteger`.
