### PR TITLE
Fixing a crash caused by an autorelease pool.

### DIFF
--- a/Source/OCMock.xcodeproj/project.pbxproj
+++ b/Source/OCMock.xcodeproj/project.pbxproj
@@ -163,6 +163,8 @@
 		2FA28FA53C57236B6DD64E82 /* OCMockObjectRuntimeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 2FA2813F93050582D83E1499 /* OCMockObjectRuntimeTests.m */; };
 		2FA28FE116284C3E4A7FF179 /* OCMInvocationExpectation.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FA288509D545BDBE094BCC8 /* OCMInvocationExpectation.h */; };
 		2FA28FEAEF9333D2C214DF53 /* NSValue+OCMAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 2FA28896E5EEFD7C2F12C2F8 /* NSValue+OCMAdditions.m */; };
+		61639FA619A4150B009F98DC /* OCMockObjectNSInvocationAutoreleaseTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 61639FA519A4150B009F98DC /* OCMockObjectNSInvocationAutoreleaseTests.m */; };
+		61639FA719A418AF009F98DC /* OCMockObjectNSInvocationAutoreleaseTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 61639FA519A4150B009F98DC /* OCMockObjectNSInvocationAutoreleaseTests.m */; };
 		D31108BA1828DB8700737925 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = D31108B81828DB8700737925 /* InfoPlist.strings */; };
 		D31108C41828DBD600737925 /* OCMockObjectPartialMocksTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 03AC5C1416DF9FA500D82ECD /* OCMockObjectPartialMocksTests.m */; };
 		D31108C51828DBD600737925 /* OCMockObjectClassMethodMockingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 039F91C516EFB493006C3D70 /* OCMockObjectClassMethodMockingTests.m */; };
@@ -286,6 +288,7 @@
 		2FA28DEDB9163597B7C49F3D /* NSMethodSignatureOCMAdditionsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSMethodSignatureOCMAdditionsTests.m; sourceTree = "<group>"; };
 		2FA28EC49F6C59B940AE6D00 /* OCMFunctions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OCMFunctions.h; sourceTree = "<group>"; };
 		2FA28EDBF243639C57F88A1B /* OCMArgTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OCMArgTests.m; sourceTree = "<group>"; };
+		61639FA519A4150B009F98DC /* OCMockObjectNSInvocationAutoreleaseTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OCMockObjectNSInvocationAutoreleaseTests.m; sourceTree = "<group>"; };
 		D31108AD1828DB8700737925 /* OCMockLibTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OCMockLibTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D31108B71828DB8700737925 /* OCMockLibTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "OCMockLibTests-Info.plist"; sourceTree = "<group>"; };
 		D31108B91828DB8700737925 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -428,6 +431,7 @@
 				03B3161F1463350E0052CD09 /* NSInvocationOCMAdditionsTests.m */,
 				2FA28DEDB9163597B7C49F3D /* NSMethodSignatureOCMAdditionsTests.m */,
 				037ECD5318FAD84100AF0E4C /* OCMInvocationMatcherTests.m */,
+				61639FA519A4150B009F98DC /* OCMockObjectNSInvocationAutoreleaseTests.m */,
 				03565A3418F0566F003AE91E /* Supporting Files */,
 				2FA2813F93050582D83E1499 /* OCMockObjectRuntimeTests.m */,
 				2FA2822E19948FC997965267 /* OCMockObjectTests.m */,
@@ -903,6 +907,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				61639FA619A4150B009F98DC /* OCMockObjectNSInvocationAutoreleaseTests.m in Sources */,
 				037ECD5418FAD84100AF0E4C /* OCMInvocationMatcherTests.m in Sources */,
 				03565A4418F05721003AE91E /* OCMockObjectProtocolMocksTests.m in Sources */,
 				03565A4B18F05721003AE91E /* NSInvocationOCMAdditionsTests.m in Sources */,
@@ -926,6 +931,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				61639FA719A418AF009F98DC /* OCMockObjectNSInvocationAutoreleaseTests.m in Sources */,
 				03C9CA1E18F05A84006DF94D /* OCMArgTests.m in Sources */,
 				0322DA66191188D100CACAF1 /* OCMockObjectVerifyAfterRunTests.m in Sources */,
 				D31108C51828DBD600737925 /* OCMockObjectClassMethodMockingTests.m in Sources */,

--- a/Source/OCMock/OCMockObject.m
+++ b/Source/OCMock/OCMockObject.m
@@ -270,12 +270,17 @@
 {
     [invocations addObject:anInvocation];
 
-    NSUInteger idx = [stubs indexOfObjectPassingTest:^BOOL(id s, NSUInteger i, BOOL *stop) {
-        return [(OCMInvocationStub *)s handleInvocation:anInvocation];
-    }];
-    if(idx == NSNotFound)
+    // Search for the stub which handles the invocation
+    // Note: we don't want to use indexOfObjectPassingTest: because it introduces an autorelease pool which causes a crash
+    OCMInvocationStub *stub = nil;
+    for (OCMInvocationStub *s in stubs) {
+        if ([s handleInvocation:anInvocation]) {
+            stub = s;
+            break;
+        }
+    }
+    if(!stub)
    		return NO;
-    OCMInvocationStub *stub = [stubs objectAtIndex:idx];
 
 	if([expectations containsObject:stub])
 	{

--- a/Source/OCMockTests/OCMockObjectNSInvocationAutoreleaseTests.m
+++ b/Source/OCMockTests/OCMockObjectNSInvocationAutoreleaseTests.m
@@ -1,0 +1,111 @@
+/*
+ *  Copyright (c) 2014 Erik Doernenburg and contributors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use these files except in compliance with the License. You may obtain
+ *  a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations
+ *  under the License.
+ */
+
+
+#import <XCTest/XCTest.h>
+#import <OCMock/OCMock.h>
+
+
+/*
+ NSInovation Autorelease Tests
+ 
+ These tests test a specific senario where the return value of an NSInvocation is released before the invocation is invoked. This will cause a crash.
+ The senarios here are contrived, but they were come upon by trying to mock an NSURLSession and NSURLSessionDataTask objects.
+ 
+ To reproduce the specific bug, reimplement handleInvocation: in OCMockObject to use indexOfObjectPassingTest: instead of the custom implementation there
+ */
+
+@interface OCMockObjectNSInvocationAutoreleaseTests : XCTestCase
+
+@end
+
+#pragma mark - Helper Class Interfaces
+// These are classes we want to mock, so don't have a good idea of their implementation
+
+@interface OCMockTestTask: NSObject
+
+- (void)runTask;
+
+@end
+
+@interface OCMockTestTaskCreator : NSObject
+
+- (OCMockTestTask *)createTaskWithBlock:(void(^)())block;
+
+@end
+
+#pragma mark - Tests
+
+@implementation OCMockObjectNSInvocationAutoreleaseTests
+
+- (void)testMockTaskCreator
+{
+    // First, let's create our mocks
+    id mockCreator = [OCMockObject mockForClass:[OCMockTestTaskCreator class]];
+    
+    // Let's stub it out, so that when we call runTask on a task, it runs our own block
+    [[[mockCreator stub] andDo:^(NSInvocation *invocation) {
+        // First, let's grab the task block
+        // We need to do some ARC fun stuff to make sure we retain this block properly
+        __unsafe_unretained void(^task)() = nil;
+        [invocation getArgument:&task atIndex:2];
+        void(^retainedTask)() = task;
+        
+        // Now, let's create a mock task
+        // Note, we use autoreleasing, because this will be returned by this method
+        // This is what we're testing. Does this get released before we try to use it?
+        __autoreleasing id mockTask = [OCMockObject mockForClass:[OCMockTestTask class]];
+        [[[mockTask stub] andDo:^(NSInvocation *invocation) {
+            // We should run the task here
+            retainedTask();
+        }] runTask];
+        
+        [invocation setReturnValue:&mockTask];
+
+    }] createTaskWithBlock:OCMOCK_ANY];
+    
+    // Now, let's try running this thing.
+    // If we don't crash, then the test succeeds. If we crash, then the test fails.
+    
+    __block BOOL success = NO;
+    OCMockTestTask *task = [mockCreator createTaskWithBlock:^{
+        success = YES;
+    }];
+    [task runTask];
+    
+    XCTAssertTrue(success, @"We should have run our custom block which set this to YES");
+}
+
+@end
+
+#pragma mark - Helper Classes Implementation
+
+@implementation OCMockTestTask
+
+- (void)runTask {
+    NSAssert(NO, @"We don't want this method to run. We are trying to mock it out so that another method runs in its place");
+}
+
+@end
+
+@implementation OCMockTestTaskCreator
+
+- (OCMockTestTask *)createTaskWithBlock:(void (^)())block {
+    NSAssert(NO, @"We don't want this method to run. We are trying to mock it out so that another method runs in its place");
+    return nil;
+}
+
+@end


### PR DESCRIPTION
We want to make sure we don't release return values for NSInvocations before they are used.

This is a fix for a bug that I found today. It looks like `indexOfObjectPassingTest` creates an autorelease pool when iterating. Since return values for NSInvocations can be captured in this pool, the return values could be released before they are used, which would cause a crash.

As far as I can see, there is no other way of writing the mocking code below for all cases. My current workaround is to create a retain cycle so the object never gets dealloced, avoiding the crash. I don't think this is a good solution.

Note: this only happens in specific situations where you use a mock within another mock context. However, I think the use case is valid and OCMock should handle it correctly. The crash is reproducible and happens every time.

I've included a unit test which fails before I make the change to OCMockObject and passes afterwards.

Thanks.
