### PR TITLE
Handle invocation arguments of type Class

### DIFF
--- a/Source/OCMock/OCMFunctions.m
+++ b/Source/OCMock/OCMFunctions.m
@@ -39,7 +39,7 @@ BOOL OCMIsObjectType(const char *objCType)
 {
     objCType = OCMTypeWithoutQualifiers(objCType);
 
-    if(strcmp(objCType, @encode(id)) == 0)
+    if(strcmp(objCType, @encode(id)) == 0 || strcmp(objCType, @encode(Class)) == 0)
         return YES;
 
     // if the returnType is a typedef to an object, it has the form ^{OriginClass=#}


### PR DESCRIPTION
I have a few method expectations where the parameter type is `Class`. It looks as though handing of this case got dropped inadvertently with 60be17f5415c2297dd790eecf55e38ff848e5a5e.
