### PR TITLE
Change remaining uses of typeof to __typeof__

### DIFF
--- a/OCMock.podspec
+++ b/OCMock.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "OCMock"
-  s.version      = "3.1.1"
+  s.version      = "3.1.2"
   
   s.summary      = "Mock objects for Objective-C"
   s.description      = <<-DESC

--- a/Source/OCMock/NSInvocation+OCMAdditions.m
+++ b/Source/OCMock/NSInvocation+OCMAdditions.m
@@ -131,7 +131,7 @@
 		{
 			long double value;
 			[self getArgument:&value atIndex:argIndex];
-			return [NSValue valueWithBytes:&value objCType:@encode(typeof(value))];
+			return [NSValue valueWithBytes:&value objCType:@encode(__typeof__(value))];
 		}
 		case 'B':
 		{

--- a/Source/OCMock/OCMStubRecorder.h
+++ b/Source/OCMock/OCMStubRecorder.h
@@ -32,7 +32,7 @@
 
 @interface OCMStubRecorder (Properties)
 
-#define andReturn(aValue) _andReturn(({ typeof(aValue) _v = (aValue); [NSValue value:&_v withObjCType:@encode(typeof(_v))]; }))
+#define andReturn(aValue) _andReturn(({ __typeof__(aValue) _v = (aValue); [NSValue value:&_v withObjCType:@encode(__typeof__(_v))]; }))
 @property (nonatomic, readonly) OCMStubRecorder *(^ _andReturn)(NSValue *);
 
 #define andThrow(anException) _andThrow(anException)

--- a/Source/OCMockTests/NSInvocationOCMAdditionsTests.m
+++ b/Source/OCMockTests/NSInvocationOCMAdditionsTests.m
@@ -22,7 +22,7 @@
 
 - (id)ocmtest_initWithLongDouble:(long double)ldbl
 {
-    return [self initWithBytes:&ldbl objCType:@encode(typeof(ldbl))];
+    return [self initWithBytes:&ldbl objCType:@encode(__typeof__(ldbl))];
 }
 
 @end


### PR DESCRIPTION
@erikdoe

This pull request changes the remaining uses of `typeof` to `__typeof__` to allow compatibility with all C, Objective-C++, etc files in addition to Objective-C files.

`__typeof__` is simply an alternate keyword for `typeof`. This change should be very safe. See this link for an explanation on why this is needed:

https://gcc.gnu.org/onlinedocs/gcc/Alternate-Keywords.html#Alternate-Keywords

I'm also requesting that the pod spec's patch version be bumped; the repo tagged; and pushed to trunk.

This change will allow several teams across our company to adopt the `OCMock 3` syntax, and we very much would appreciate its inclusion.

Thanks again for the great work on OCMock, Erik!

- Joshua