### PR TITLE
Fixed bug where reject, then expect would cause issues if using expectationOrderMatters.

### DIFF
--- a/Source/OCMock/OCMInvocationExpectation.h
+++ b/Source/OCMock/OCMInvocationExpectation.h
@@ -23,6 +23,7 @@
 }
 
 - (void)setMatchAndReject:(BOOL)flag;
+- (BOOL)isMatchAndReject;
 
 - (BOOL)isSatisfied;
 

--- a/Source/OCMock/OCMInvocationExpectation.m
+++ b/Source/OCMock/OCMInvocationExpectation.m
@@ -27,6 +27,11 @@
         isSatisfied = YES;
 }
 
+- (BOOL)isMatchAndReject
+{
+  return matchAndReject;
+}
+
 - (BOOL)isSatisfied
 {
     return isSatisfied;

--- a/Source/OCMock/OCMockObject.m
+++ b/Source/OCMock/OCMockObject.m
@@ -266,6 +266,18 @@
     }
 }
 
+- (OCMInvocationExpectation *)_firstNonNeverExpectation
+{
+    for (OCMInvocationExpectation *expectation in expectations)
+    {
+        if (![expectation isMatchAndReject])
+        {
+            return expectation;
+        }
+    }
+    return nil;
+}
+
 - (BOOL)handleInvocation:(NSInvocation *)anInvocation
 {
     [invocations addObject:anInvocation];
@@ -279,22 +291,21 @@
     if(stub == nil)
         return NO;
 
-	if([expectations containsObject:stub])
-	{
-		if(expectationOrderMatters && ([expectations objectAtIndex:0] != stub))
-		{
-			[NSException raise:NSInternalInconsistencyException	format:@"%@: unexpected method invoked: %@\n\texpected:\t%@",  
-			 [self description], [stub description], [[expectations objectAtIndex:0] description]];
-			
-		}
+    if([expectations containsObject:stub])
+    {
+        OCMInvocationExpectation *expectation = [self _firstNonNeverExpectation];
+        if(expectationOrderMatters && expectation && (expectation != stub))
+        {
+            [NSException raise:NSInternalInconsistencyException format:@"%@: unexpected method invoked: %@\n\texpected:\t%@", [self description], [stub description], [[expectations objectAtIndex:0] description]];
+        }
         if([(OCMInvocationExpectation *)stub isSatisfied])
         {
             [expectations removeObject:stub];
             [stubs removeObject:stub];
         }
-	}
+    }
 
-	return YES;
+    return YES;
 }
 
 - (void)handleUnRecordedInvocation:(NSInvocation *)anInvocation

--- a/Source/OCMockTests/OCMockObjectPartialMocksTests.m
+++ b/Source/OCMockTests/OCMockObjectPartialMocksTests.m
@@ -245,6 +245,16 @@ static NSUInteger initializeCallCount = 0;
                                  @"should throw NSInvalidArgumentException exception");
 }
 
+- (void)testRejectThenExpectWithExpectationOrdering
+{
+    TestClassThatCallsSelf *object = [[TestClassThatCallsSelf alloc] init];
+    id mock = OCMPartialMock(object);
+    [mock setExpectationOrderMatters:YES];
+    [[mock reject] method1];
+    [[mock expect] method2];
+    XCTAssertNoThrow([object method2], @"Since method1 should be rejected, we shouldn't expect it to be called before method2.");
+}
+
 #if TARGET_RT_64_BIT
 
 - (void)testRefusesToCreatePartialMockForTaggedPointers


### PR DESCRIPTION
Fixes #155 and adds a test for it.
