### PR TITLE
Fix makefile for Xcode6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 
 BUILD_DIR = OBJROOT="$(CURDIR)/build" SYMROOT="$(CURDIR)/build"
 SHELL = /bin/bash -e -o pipefail
-IPHONE = -scheme OCMockLib -sdk iphonesimulator -destination 'name=iPhone Retina (4-inch)' $(BUILD_DIR)
+IPHONE = -scheme OCMockLib -sdk iphonesimulator -destination 'name=iPhone 4S' $(BUILD_DIR)
 MACOSX = -scheme OCMock -sdk macosx $(BUILD_DIR)
 XCODEBUILD = xcodebuild -project "$(CURDIR)/Source/OCMock.xcodeproj"
 


### PR DESCRIPTION
travis-cl now uses Xcode6 for iOS builds, which has a different name for the iPhone simulator.
