### PR TITLE
Added test coverage for OCMArg's `resolveSpecialValues` class method

### DIFF
--- a/Source/OCMockTests/OCMArgTests.m
+++ b/Source/OCMockTests/OCMArgTests.m
@@ -65,4 +65,20 @@
     
 }
 
+-(void)testResolvesArbitrarySelectorToItself{
+
+    NSValue *arbirary = [NSValue value:NSSelectorFromString(@"someSelector") withObjCType:@encode(SEL)];
+    XCTAssertEqual([OCMArg resolveSpecialValues:arbirary], arbirary, @"Arbirary selector is not resolved to itself");
+    
+}
+
+-(void)testResolvesAnyPointerToAny{
+
+    void *anyPointer = [OCMArg anyPointer];
+    NSValue *anyPointerValue = [NSValue valueWithPointer:anyPointer];
+    
+    XCTAssertTrue([[OCMArg resolveSpecialValues:anyPointerValue] isKindOfClass:[OCMAnyConstraint class]]);
+
+}
+
 @end

--- a/Source/OCMockTests/OCMArgTests.m
+++ b/Source/OCMockTests/OCMArgTests.m
@@ -56,4 +56,13 @@
 	XCTAssertFalse([constraint evaluate:nil], @"Should not have accepted nil.");
 }
 
+-(void)testResolvesAnySelectorToAny{
+
+    SEL anySelector = [OCMArg anySelector];
+    NSValue *anySelectorValue = [NSValue valueWithBytes:&anySelector objCType:@encode(SEL)];
+    
+    XCTAssertTrue([[OCMArg resolveSpecialValues:anySelectorValue] isKindOfClass:[OCMAnyConstraint class]]);
+    
+}
+
 @end

--- a/Source/OCMockTests/OCMArgTests.m
+++ b/Source/OCMockTests/OCMArgTests.m
@@ -17,6 +17,7 @@
 #import <XCTest/XCTest.h>
 #import "OCMArg.h"
 #import "OCMConstraint.h"
+#import "OCMPassByRefSetter.h"
 
 #if TARGET_OS_IPHONE
 #define NSRect CGRect
@@ -73,12 +74,21 @@
 }
 
 -(void)testResolvesAnyPointerToAny{
-
+    
     void *anyPointer = [OCMArg anyPointer];
     NSValue *anyPointerValue = [NSValue valueWithPointer:anyPointer];
     
     XCTAssertTrue([[OCMArg resolveSpecialValues:anyPointerValue] isKindOfClass:[OCMAnyConstraint class]]);
+    
+}
 
+-(void)testResolvesPassByRefSetterValueToItsPointer{
+    
+    NSNumber *value = @1;
+    OCMPassByRefSetter *setter = [[OCMPassByRefSetter alloc] initWithValue:value];
+    NSValue *passByRefSetterValue = [NSValue value:&setter withObjCType:@encode(void *)];
+    XCTAssertEqual([OCMArg resolveSpecialValues:passByRefSetterValue], setter, @"NSValue wrapping OCMPassByRefSetter does not resolve to the underlying OCMPassByRefSetter");
+    
 }
 
 @end


### PR DESCRIPTION
Added 4 tests to cover `[OCMArg resolveSpecialValues:...]`.