### PR TITLE
Fixing crash on nil object being mocked

### DIFF
--- a/Source/OCMock/OCClassMockObject.m
+++ b/Source/OCMock/OCClassMockObject.m
@@ -26,6 +26,7 @@
 
 - (id)initWithClass:(Class)aClass
 {
+    NSParameterAssert(aClass != nil);
 	[super init];
 	mockedClass = aClass;
     [self prepareClassForClassMethodMocking];

--- a/Source/OCMock/OCPartialMockObject.m
+++ b/Source/OCMock/OCPartialMockObject.m
@@ -29,6 +29,7 @@
 
 - (id)initWithObject:(NSObject *)anObject
 {
+    NSParameterAssert(anObject != nil);
     [self assertClassIsSupported:[anObject class]];
 	[super initWithClass:[anObject class]];
 	realObject = [anObject retain];

--- a/Source/OCMock/OCProtocolMockObject.m
+++ b/Source/OCMock/OCProtocolMockObject.m
@@ -24,6 +24,7 @@
 
 - (id)initWithProtocol:(Protocol *)aProtocol
 {
+    NSParameterAssert(aProtocol != nil);
 	[super init];
 	mockedProtocol = aProtocol;
 	return self;

--- a/Source/OCMockTests/OCMockObjectClassMethodMockingTests.m
+++ b/Source/OCMockTests/OCMockObjectClassMethodMockingTests.m
@@ -314,4 +314,11 @@ static NSUInteger initializeCallCount = 0;
 }
 
 
+#pragma mark    Test for nil to raise an exception instead of crash
+
+- (void)testMockingNilDoesntCrashTests
+{
+    XCTAssertThrows(OCMClassMock(nil));
+}
+
 @end

--- a/Source/OCMockTests/OCMockObjectPartialMocksTests.m
+++ b/Source/OCMockTests/OCMockObjectPartialMocksTests.m
@@ -423,4 +423,12 @@ static NSUInteger initializeCallCount = 0;
 }
 
 
+#pragma mark    Test for nil to raise an exception instead of crash
+
+- (void)testMockingNilDoesntCrashTests
+{
+    XCTAssertThrows(OCMPartialMock(nil));
+}
+
+
 @end

--- a/Source/OCMockTests/OCMockObjectProtocolMocksTests.m
+++ b/Source/OCMockTests/OCMockObjectProtocolMocksTests.m
@@ -147,4 +147,12 @@ typedef InterfaceForTypedef* PointerTypedefInterface;
     XCTAssertEqual(@"stubbed", result, @"Should have stubbed the class method.");
 }
 
+
+#pragma mark    Test for nil to raise an exception instead of crash
+
+- (void)testMockingNilDoesntCrashTests
+{
+    XCTAssertThrows(OCMProtocolMock(nil));
+}
+
 @end


### PR DESCRIPTION
I found that when a mock is created with a nil object OCMock will hard crash. This is because nil propagation hides the issue until a call to `objc_setAssociatedObject` where the class being nil causes a hard crash.

I've added explicit parameter asserts for the three mocks so that the issue can be caught immediately and, more importantly, will raise an exception that Xcode can catch rather than crashing the tests entirely.