### PR TITLE
Fix OCMEqualTypesAllowingOpaqueStructsInternal when type2 is opaque

### DIFF
--- a/Source/OCMock/OCMFunctions.m
+++ b/Source/OCMock/OCMFunctions.m
@@ -103,7 +103,7 @@ static BOOL OCMEqualTypesAllowingOpaqueStructsInternal(const char *type1, const 
             BOOL type1Opaque = (type1Equals == NULL || (type1End < type1Equals) || type1Equals[1] == endChar);
             BOOL type2Opaque = (type2Equals == NULL || (type2End < type2Equals) || type2Equals[1] == endChar);
             const char *type1NameEnd = (type1Equals == NULL || (type1End < type1Equals)) ? type1End : type1Equals;
-            const char *type2NameEnd = (type1Equals == NULL || (type2End < type2Equals)) ? type2End : type2Equals;
+            const char *type2NameEnd = (type2Equals == NULL || (type2End < type2Equals)) ? type2End : type2Equals;
             intptr_t type1NameLen = type1NameEnd - type1;
             intptr_t type2NameLen = type2NameEnd - type2;
 

--- a/Source/OCMockTests/OCMockObjectTests.m
+++ b/Source/OCMockTests/OCMockObjectTests.m
@@ -492,8 +492,16 @@ static NSString *TestNotification = @"TestNotification";
     "::DefaultDeleter<GURL> >={scoped_ptr_impl<GURL, base::DefaultDeleter<GURL"
     "> >={Data=^{GURL}}}}}";
 
+    const char *type3 =
+    "r^{GURL}";
+
     OCMBoxedReturnValueProvider *boxed = [OCMBoxedReturnValueProvider new];
     XCTAssertTrue([boxed isMethodReturnType:type1 compatibleWithValueType:type2]);
+    XCTAssertTrue([boxed isMethodReturnType:type1 compatibleWithValueType:type3]);
+    XCTAssertTrue([boxed isMethodReturnType:type2 compatibleWithValueType:type1]);
+    XCTAssertTrue([boxed isMethodReturnType:type2 compatibleWithValueType:type3]);
+    XCTAssertTrue([boxed isMethodReturnType:type3 compatibleWithValueType:type1]);
+    XCTAssertTrue([boxed isMethodReturnType:type3 compatibleWithValueType:type2]);
 }
 
 - (void)testReturnsStubbedNilReturnValue


### PR DESCRIPTION
There was a typo in the initialization of type2NameEnd when type2 was
fully opaque causing OCMEqualTypesAllowingOpaqueStructsInternal() to
fails even though the types had the same name.

Introduce unit tests to test that case, and to ensure that the function
is symmetrical for its two arguments.