### PR TITLE
Add flag to optionally retain invocation arguments

### DIFF
--- a/Source/OCMock/OCMockObject.h
+++ b/Source/OCMock/OCMockObject.h
@@ -27,6 +27,7 @@
 {
 	BOOL			isNice;
 	BOOL			expectationOrderMatters;
+	BOOL			retainArguments;
 	NSMutableArray	*stubs;
 	NSMutableArray	*expectations;
 	NSMutableArray	*exceptions;
@@ -45,6 +46,7 @@
 - (instancetype)init;
 
 - (void)setExpectationOrderMatters:(BOOL)flag;
+- (void)setRetainArguments:(BOOL)flag;
 
 - (id)stub;
 - (id)expect;

--- a/Source/OCMock/OCMockObject.m
+++ b/Source/OCMock/OCMockObject.m
@@ -128,6 +128,11 @@
     expectationOrderMatters = flag;
 }
 
+- (void)setRetainArguments:(BOOL)flag
+{
+    retainArguments = flag;
+}
+
 - (void)stopMocking
 {
     // no-op for mock objects that are not class object or partial mocks
@@ -254,6 +259,10 @@
 
 - (void)forwardInvocation:(NSInvocation *)anInvocation
 {
+    if (retainArguments) {
+        [anInvocation retainArguments];
+    }
+
     @try
     {
         if([self handleInvocation:anInvocation] == NO)


### PR DESCRIPTION
Moin Erik,

I'd like to describe our use case a little to shed some light into the `why`: We use [KIF](https://github.com/kif-framework/KIF) for testing our UI. In these UI tests we inject a mock of our analytics tracker into the application. The UI tests are using the application like a normal user would do, going from screen to screen. During that time, the mock tracker is recording the tracking method calls. At the end of a test case we can assert that all the tracking calls were made properly.

If you comment out `[mock setRetainArguments:YES];` in the test case, it will crash. The `NSInvocation` does not retain the arguments by default. So they are not accessible anymore when the assertion will execute the matcher code.

This commit addresses this issue by optionally giving the user of `OCMock` the possibility to retain the `NSInvocation` arguments (per mocked object). *Maybe* this could also be the default behaviour - what do you think?

Thanks for looking into this!

Cheers,
plu