### PR TITLE
Fix issues identified by Infer

### DIFF
--- a/Source/OCMock/OCMBlockCaller.m
+++ b/Source/OCMock/OCMBlockCaller.m
@@ -21,8 +21,11 @@
 
 -(id)initWithCallBlock:(void (^)(NSInvocation *))theBlock 
 {
-	self = [super init];
-	block = [theBlock copy];
+    if ((self = [super init]))
+    {
+        block = [theBlock copy];
+    }
+    
 	return self;
 }
 

--- a/Source/OCMock/OCMConstraint.m
+++ b/Source/OCMock/OCMConstraint.m
@@ -134,8 +134,11 @@
 
 - (instancetype)initWithConstraintBlock:(BOOL (^)(id))aBlock
 {
-	self = [super init];
-	block = [aBlock copy];
+    if ((self = [super init]))
+    {
+        block = [aBlock copy];
+    }
+	
 	return self;
 }
 
@@ -146,7 +149,7 @@
 
 - (BOOL)evaluate:(id)value 
 {
-	return block(value);
+    return block ? block(value) : NO;
 }
 
 

--- a/Source/OCMock/OCMFunctions.m
+++ b/Source/OCMock/OCMFunctions.m
@@ -189,8 +189,8 @@ Class OCMGetIsa(id object)
 
 #pragma mark  Alias for renaming real methods
 
-NSString *OCMRealMethodAliasPrefix = @"ocmock_replaced_";
-const char *OCMRealMethodAliasPrefixCString = "ocmock_replaced_";
+static NSString *const OCMRealMethodAliasPrefix = @"ocmock_replaced_";
+static const char *const OCMRealMethodAliasPrefixCString = "ocmock_replaced_";
 
 BOOL OCMIsAliasSelector(SEL selector)
 {
@@ -217,7 +217,7 @@ SEL OCMOriginalSelectorForAlias(SEL selector)
 
 #pragma mark  Wrappers around associative references
 
-NSString *OCMClassMethodMockObjectKey = @"OCMClassMethodMockObjectKey";
+static NSString *const OCMClassMethodMockObjectKey = @"OCMClassMethodMockObjectKey";
 
 void OCMSetAssociatedMockForClass(OCClassMockObject *mock, Class aClass)
 {
@@ -238,7 +238,7 @@ OCClassMockObject *OCMGetAssociatedMockForClass(Class aClass, BOOL includeSuperc
     return mock;
 }
 
-NSString *OCMPartialMockObjectKey = @"OCMPartialMockObjectKey";
+static NSString *const OCMPartialMockObjectKey = @"OCMPartialMockObjectKey";
 
 void OCMSetAssociatedMockForObject(OCClassMockObject *mock, id anObject)
 {

--- a/Source/OCMock/OCMIndirectReturnValueProvider.m
+++ b/Source/OCMock/OCMIndirectReturnValueProvider.m
@@ -23,9 +23,12 @@
 
 - (id)initWithProvider:(id)aProvider andSelector:(SEL)aSelector
 {
-	self = [super init];
-	provider = [aProvider retain];
-	selector = aSelector;
+    if ((self = [super init]))
+    {
+        provider = [aProvider retain];
+        selector = aSelector;
+    }
+	
 	return self;
 }
 

--- a/Source/OCMock/OCMLocation.m
+++ b/Source/OCMock/OCMLocation.m
@@ -25,10 +25,13 @@
 
 - (instancetype)initWithTestCase:(id)aTestCase file:(NSString *)aFile line:(NSUInteger)aLine
 {
-    self = [super init];
-    testCase = aTestCase;
-    file = [aFile retain];
-    line = aLine;
+    if ((self = [super init]))
+    {
+        testCase = aTestCase;
+        file = [aFile retain];
+        line = aLine;
+    }
+    
     return self;
 }
 

--- a/Source/OCMock/OCMMacroState.m
+++ b/Source/OCMock/OCMMacroState.m
@@ -24,7 +24,7 @@
 
 @implementation OCMMacroState
 
-OCMMacroState *globalState;
+static OCMMacroState *globalState;
 
 #pragma mark  Methods to begin/end macros
 
@@ -79,8 +79,11 @@ OCMMacroState *globalState;
 
 - (id)initWithRecorder:(OCMRecorder *)aRecorder
 {
-    self = [super init];
-    recorder = [aRecorder retain];
+    if ((self = [super init]))
+    {
+        recorder = [aRecorder retain];
+    }
+    
     return self;
 }
 

--- a/Source/OCMock/OCMNotificationPoster.m
+++ b/Source/OCMock/OCMNotificationPoster.m
@@ -21,8 +21,11 @@
 
 - (id)initWithNotification:(id)aNotification
 {
-	self = [super init];
-	notification = [aNotification retain];
+    if ((self = [super init]))
+    {
+        notification = [aNotification retain];
+    }
+	
 	return self;
 }
 

--- a/Source/OCMock/OCMPassByRefSetter.m
+++ b/Source/OCMock/OCMPassByRefSetter.m
@@ -21,8 +21,11 @@
 
 - (id)initWithValue:(id)aValue
 {
-	self = [super init];
-	value = [aValue retain];
+    if ((self = [super init]))
+    {
+        value = [aValue retain];
+    }
+	
 	return self;
 }
 

--- a/Source/OCMock/OCMReturnValueProvider.m
+++ b/Source/OCMock/OCMReturnValueProvider.m
@@ -23,8 +23,11 @@
 
 - (instancetype)initWithValue:(id)aValue
 {
-	self = [super init];
-	returnValue = [aValue retain];
+    if ((self = [super init]))
+    {
+        returnValue = [aValue retain];
+    }
+	
 	return self;
 }
 

--- a/Source/OCMock/OCMVerifier.m
+++ b/Source/OCMock/OCMVerifier.m
@@ -25,8 +25,11 @@
 
 - (id)init
 {
-    self = [super init];
-    invocationMatcher = [[OCMInvocationMatcher alloc] init];
+    if ((self = [super init]))
+    {
+        invocationMatcher = [[OCMInvocationMatcher alloc] init];
+    }
+    
     return self;
 }
 

--- a/Source/OCMock/OCObserverMockObject.m
+++ b/Source/OCMock/OCObserverMockObject.m
@@ -26,9 +26,12 @@
 
 - (id)init
 {
-	self = [super init];
-	recorders = [[NSMutableArray alloc] init];
-	centers = [[NSMutableArray alloc] init];
+    if ((self = [super init]))
+    {
+        recorders = [[NSMutableArray alloc] init];
+        centers = [[NSMutableArray alloc] init];
+    }
+	
 	return self;
 }
 

--- a/Source/OCMockTests/OCMConstraintTests.m
+++ b/Source/OCMockTests/OCMConstraintTests.m
@@ -143,5 +143,11 @@
 	XCTAssertEqualObjects(@"bar", captured, @"Should have captured value from last invocation.");
 }
 
+- (void)testEvaluateNilBlockReturnsNo
+{
+    OCMBlockConstraint *constraint = [[OCMBlockConstraint alloc] initWithConstraintBlock:nil];
+    
+    XCTAssertFalse([constraint evaluate:@"foo"]);
+}
 
 @end


### PR DESCRIPTION
Fixing issues identified by [Infer](https://github.com/facebook/infer)

```
OCMock/OCMBlockCaller.m:25: error: NULL_DEREFERENCE
   pointer self last assigned on line 24 could be null and is dereferenced at line 25, column 2

OCMock/OCMConstraint.m:149: warning: IVAR_NOT_NULL_CHECKED
   Instance variable self -> block is not checked for null, there could be a null pointer dereference: pointer self->block last accessed on line 149 could be null and is dereferenced at line 149, column 9

OCMock/OCMIndirectReturnValueProvider.m:27: error: NULL_DEREFERENCE
   pointer self last assigned on line 26 could be null and is dereferenced at line 27, column 2

OCMock/OCMLocation.m:29: error: NULL_DEREFERENCE
   pointer self last assigned on line 28 could be null and is dereferenced at line 29, column 5

OCMock/OCMMacroState.m:83: error: NULL_DEREFERENCE
   pointer self last assigned on line 82 could be null and is dereferenced at line 83, column 5

OCMock/OCMNotificationPoster.m:25: error: NULL_DEREFERENCE
   pointer self last assigned on line 24 could be null and is dereferenced at line 25, column 2

OCMock/OCMPassByRefSetter.m:25: error: NULL_DEREFERENCE
   pointer self last assigned on line 24 could be null and is dereferenced at line 25, column 2

OCMock/OCMReturnValueProvider.m:27: error: NULL_DEREFERENCE
   pointer self last assigned on line 26 could be null and is dereferenced at line 27, column 2

OCMock/OCMVerifier.m:29: error: NULL_DEREFERENCE
   pointer self last assigned on line 28 could be null and is dereferenced at line 29, column 5

OCMock/OCObserverMockObject.m:30: error: NULL_DEREFERENCE
   pointer self last assigned on line 29 could be null and is dereferenced at line 30, column 2
```