### PR TITLE
Fixed early release of stubs that use `andReturn()` in ARC.

### DIFF
--- a/Source/OCMock/OCMStubRecorder.h
+++ b/Source/OCMock/OCMStubRecorder.h
@@ -15,7 +15,7 @@
  */
 
 #import "OCMRecorder.h"
-
+#import <objc/runtime.h>
 
 @interface OCMStubRecorder : OCMRecorder
 
@@ -32,7 +32,15 @@
 
 @interface OCMStubRecorder (Properties)
 
-#define andReturn(aValue) _andReturn(({ __typeof__(aValue) _v = (aValue); [NSValue value:&_v withObjCType:@encode(__typeof__(_v))]; }))
+#define andReturn(aValue) _andReturn(({                                                                       \
+  __typeof__(aValue) _v = (aValue);                                                                           \
+  NSValue *__v = [NSValue value:&_v withObjCType:@encode(__typeof__(_v))];                                    \
+  if (__builtin_types_compatible_p(__typeof__(aValue), id)) {                                                 \
+      objc_setAssociatedObject(__v, &_v, *(__unsafe_unretained id *) (void *) &_v, OBJC_ASSOCIATION_RETAIN);  \
+  }                                                                                                           \
+                                                                                                              \
+  __v;                                                                                                        \
+}))
 @property (nonatomic, readonly) OCMStubRecorder *(^ _andReturn)(NSValue *);
 
 #define andThrow(anException) _andThrow(anException)


### PR DESCRIPTION
This fixes issue #192.

This was happening because in ARC, when you create a temporary value, it defaults to being `__strong`, meaning it will be released as soon as the scope ends. Because of the GCC statement expression there the code between (`({ ... })`), the scope in which the temporary value was created was being destroyed before being passed to the `andReturn` block.

We fix this by using a GCC/clang extension, `__builtin_choose_expr`, to add an associated object to the `NSValue` returned by the temporary scope, only if the type of the value is an object, so that it will also work for primitive types/structs. 

Thanks to @nlutsenko for helping me construct this crazy solution!