### PR TITLE
Update Travis configuration to use latest Xcode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
-language: objective-c  
+language: objective-c
+osx_image: xcode6.4
 before_install:
-    - gem install xcpretty --no-rdoc --no-ri --no-document --quiet
-script: make
+    - gem install xcpretty -N --quiet
+script: make ci

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,8 @@
 
 BUILD_DIR = OBJROOT="$(CURDIR)/build" SYMROOT="$(CURDIR)/build"
 SHELL = /bin/bash -e -o pipefail
-IPHONE = -scheme OCMockLib -sdk iphonesimulator -destination 'name=iPhone 4S' $(BUILD_DIR)
+IOS32 = -scheme OCMockLib -sdk iphonesimulator -destination 'name=iPhone 5' $(BUILD_DIR)
+IOS64 = -scheme OCMockLib -sdk iphonesimulator -destination 'name=iPhone 5s' $(BUILD_DIR)
 MACOSX = -scheme OCMock -sdk macosx $(BUILD_DIR)
 XCODEBUILD = xcodebuild -project "$(CURDIR)/Source/OCMock.xcodeproj"
 
@@ -17,11 +18,17 @@ clean:
 	$(XCODEBUILD) clean
 	rm -rf "$(CURDIR)/build"
 
-test: test-iphone test-macosx
+test: test-ios test-macosx
 
-test-iphone:
-	@echo "Running iPhone tests..."
-	$(XCODEBUILD) $(IPHONE) test | xcpretty -c
+test-ios: test-ios32 test-ios64
+
+test-ios32:
+	@echo "Running 32-bit iOS tests..."
+	$(XCODEBUILD) $(IOS32) test | xcpretty -c
+
+test-ios64:
+	@echo "Running 64-bit iOS tests..."
+	$(XCODEBUILD) $(IOS64) test | xcpretty -c
 
 test-macosx:
 	@echo "Running OS X tests..."


### PR DESCRIPTION
Updating the TravisCI configuration. This does the following:
- Builds on OS X Yosemite instead of Mavericks
- Builds using Xcode 6.4 instead of Xcode 6.1
- Tests 32-bit & 64-bit iOS builds
- Allows code using nullability annotations (introduced in Xcode 6.3) to be built on Travis
- Makes it easier to switch to Xcode 7 once available