### PR TITLE
Silence build error when using typed mock

### DIFF
--- a/Source/OCMock/OCMock.h
+++ b/Source/OCMock/OCMock.h
@@ -62,9 +62,9 @@
     );
 
 
-#define OCMVerifyAll(mock) [mock verifyAtLocation:OCMMakeLocation(self, __FILE__, __LINE__)]
+#define OCMVerifyAll(mock) [(OCMockObject *)mock verifyAtLocation:OCMMakeLocation(self, __FILE__, __LINE__)]
 
-#define OCMVerifyAllWithDelay(mock, delay) [mock verifyWithDelay:delay atLocation:OCMMakeLocation(self, __FILE__, __LINE__)]
+#define OCMVerifyAllWithDelay(mock, delay) [(OCMockObject *)mock verifyWithDelay:delay atLocation:OCMMakeLocation(self, __FILE__, __LINE__)]
 
 #define OCMVerify(invocation) \
 ({ \

--- a/Source/OCMockTests/OCMockObjectProtocolMocksTests.m
+++ b/Source/OCMockTests/OCMockObjectProtocolMocksTests.m
@@ -152,4 +152,18 @@ typedef InterfaceForTypedef* PointerTypedefInterface;
     XCTAssertThrows(OCMProtocolMock(nil));
 }
 
+- (void)testOCMVerifyAllTypedMock
+{
+    id <NSLocking> mock = OCMStrictProtocolMock(@protocol(NSLocking));
+    OCMExpect([mock lock]);
+
+    [mock lock];
+
+    // The purpose of these tests is not the actual execution, but to assure that the
+    // compiler raises no errors if the mock object has been declared with a different
+    // type than id.
+    OCMVerifyAll(mock);
+    OCMVerifyAllWithDelay(mock, 0.001);
+}
+
 @end


### PR DESCRIPTION
Consider the following test:

```objc
id <NSLocking> mock = OCMStrictProtocolMock(@protocol(NSLocking));
OCMExpect([mock lock]);

[mock lock];

OCMVerifyAll(mock);
// error: No known instance method for selector 'verifyAtLocation:'
```

Because we have given the mock object a type of `id <NSLocking>` instead of just `id` (which is helpful for documentation and code completion etc. when writing the test), the call to `OCMVerifyAll()` doesn't compile because of a type mismatch.

The fix casts the mock object explicitly to OCMockObject in the
OCMVerifyAll() and OCMVerifyWithDelay() macros.

_Edit: Here's a screenshot showing the error:_
<img width="1095" alt="ocmock-build-error" src="https://cloud.githubusercontent.com/assets/5010/9293809/5eab43ee-4439-11e5-9d9a-04885f6abc0a.png">
