### PR TITLE
Runtime check of andReturn() value type rather than static

### DIFF
--- a/Source/OCMock/OCMFunctions.h
+++ b/Source/OCMock/OCMFunctions.h
@@ -25,9 +25,9 @@ BOOL OCMIsObjectType(const char *objCType);
 const char *OCMTypeWithoutQualifiers(const char *objCType);
 BOOL OCMEqualTypesAllowingOpaqueStructs(const char *type1, const char *type2);
 
-Class OCMCreateSubclass(Class class, void *ref);
+Class OCMCreateSubclass(Class kl, void *ref);
 
-void OCMSetIsa(id object, Class class);
+void OCMSetIsa(id object, Class kl);
 Class OCMGetIsa(id object);
 
 BOOL OCMIsAliasSelector(SEL selector);

--- a/Source/OCMock/OCMStubRecorder.h
+++ b/Source/OCMock/OCMStubRecorder.h
@@ -15,6 +15,7 @@
  */
 
 #import "OCMRecorder.h"
+#import "OCMFunctions.h"
 #import <objc/runtime.h>
 
 @interface OCMStubRecorder : OCMRecorder

--- a/Source/OCMock/OCMStubRecorder.h
+++ b/Source/OCMock/OCMStubRecorder.h
@@ -35,7 +35,7 @@
 #define andReturn(aValue) _andReturn(({                                             \
   __typeof__(aValue) _val = (aValue);                                               \
   NSValue *_nsval = [NSValue value:&_val withObjCType:@encode(__typeof__(_val))];   \
-  if (__builtin_types_compatible_p(__typeof__(_val), id)) {                         \
+  if (OCMIsObjectType(@encode(__typeof(_val)))) {                                   \
       objc_setAssociatedObject(_nsval, "OCMAssociatedBoxedValue", *(__unsafe_unretained id *) (void *) &_val, OBJC_ASSOCIATION_RETAIN); \
   }                                                                                 \
   _nsval;                                                                           \


### PR DESCRIPTION
See http://stackoverflow.com/questions/32503134/change-to-andreturn-breaks-c-compilation.

Perform runtime check of value as objc object is compatible with C++ compilation. Static is not.