### PR TITLE
Fix linking in Objective–C++ tests.

### DIFF
--- a/Source/OCMock/OCMLocation.h
+++ b/Source/OCMock/OCMLocation.h
@@ -33,4 +33,9 @@
 
 @end
 
-extern OCMLocation *OCMMakeLocation(id testCase, const char *file, int line);
+#if defined(__cplusplus)
+extern "C"
+#else
+extern
+#endif
+OCMLocation *OCMMakeLocation(id testCase, const char *file, int line);


### PR DESCRIPTION
As detailed in #238, linking tests sometimes fails when OCMock is being used in Objective-C++ (.mm) test case files.
This commit solves that problem by conditionally declaring `OCMMakeLocation` as `extern "C"` when included in a C++ compilation unit, therefore fixing #238.