### PR TITLE
Remove direct isa pointer manipulation

### DIFF
--- a/Source/OCMock/OCMFunctions.m
+++ b/Source/OCMock/OCMFunctions.m
@@ -174,19 +174,6 @@ Class OCMCreateSubclass(Class class, void *ref)
 }
 
 
-#pragma mark  Directly manipulating the isa pointer (look away)
-
-void OCMSetIsa(id object, Class class)
-{
-    *((Class *)object) = class;
-}
-
-Class OCMGetIsa(id object)
-{
-    return *((Class *)object);
-}
-
-
 #pragma mark  Alias for renaming real methods
 
 static NSString *const OCMRealMethodAliasPrefix = @"ocmock_replaced_";

--- a/Source/OCMock/OCMFunctionsPrivate.h
+++ b/Source/OCMock/OCMFunctionsPrivate.h
@@ -34,9 +34,6 @@ BOOL OCMEqualTypesAllowingOpaqueStructs(const char *type1, const char *type2);
 
 Class OCMCreateSubclass(Class cls, void *ref);
 
-void OCMSetIsa(id object, Class cls);
-Class OCMGetIsa(id object);
-
 BOOL OCMIsAliasSelector(SEL selector);
 SEL OCMAliasForOriginalSelector(SEL selector);
 SEL OCMOriginalSelectorForAlias(SEL selector);


### PR DESCRIPTION
Removed direct usages of isa pointer.  That is a bad idea these days because of tagged pointers -- the raw pointer values may not be valid Class objects.  They were only used to manipulate meta classes though and those may have been OK.  However, object_getClass and object_setClass works just fine for them... at least, the unit tests still pass after I made the changes.

If there was some other reason to be directly changing the isa pointers I'm not aware of, ignore this pull request -- but it's a dangerous thing to be doing now.  object_setClass() goes through some runtime stuff now which may eventually be more important.