### PR TITLE
Potential solution for testing optional methods on protocol mocks where we want to control -respondsToSele…

### DIFF
--- a/Source/OCMock/OCMockObject.h
+++ b/Source/OCMock/OCMockObject.h
@@ -35,6 +35,7 @@
 
 + (id)mockForClass:(Class)aClass;
 + (id)mockForProtocol:(Protocol *)aProtocol;
++ (id)respondingMockForProtocol:(Protocol *)aProtocol;
 + (id)partialMockForObject:(NSObject *)anObject;
 
 + (id)niceMockForClass:(Class)aClass;

--- a/Source/OCMock/OCMockObject.m
+++ b/Source/OCMock/OCMockObject.m
@@ -53,6 +53,11 @@
 	return [[[OCProtocolMockObject alloc] initWithProtocol:aProtocol] autorelease];
 }
 
++ (id)respondingMockForProtocol:(Protocol *)aProtocol
+{
+    return [[[OCRespondingProtocolMockObject alloc] initWithProtocol:aProtocol] autorelease];
+}
+
 + (id)partialMockForObject:(NSObject *)anObject
 {
 	return [[[OCPartialMockObject alloc] initWithObject:anObject] autorelease];

--- a/Source/OCMock/OCProtocolMockObject.h
+++ b/Source/OCMock/OCProtocolMockObject.h
@@ -25,3 +25,5 @@
 
 @end
 
+@interface OCRespondingProtocolMockObject : OCProtocolMockObject
+@end

--- a/Source/OCMock/OCProtocolMockObject.m
+++ b/Source/OCMock/OCProtocolMockObject.m
@@ -38,16 +38,23 @@
 
 #pragma mark  Proxy API
 
-- (NSMethodSignature *)methodSignatureForSelector:(SEL)aSelector
+- (NSMethodSignature *)methodSignatureForSelector:(SEL)aSelector isRequired:(BOOL *)required
 {
     struct { BOOL isRequired; BOOL isInstance; } opts[4] = { {YES, YES}, {NO, YES}, {YES, NO}, {NO, NO} };
     for(int i = 0; i < 4; i++)
     {
         struct objc_method_description methodDescription = protocol_getMethodDescription(mockedProtocol, aSelector, opts[i].isRequired, opts[i].isInstance);
-        if(methodDescription.name != NULL)
+        if(methodDescription.name != NULL) {
+            if (required) *required = opts[i].isRequired;
             return [NSMethodSignature signatureWithObjCTypes:methodDescription.types];
+        }
     }
     return nil;
+}
+
+- (NSMethodSignature *)methodSignatureForSelector:(SEL)aSelector
+{
+    return [self methodSignatureForSelector:aSelector isRequired:NULL];
 }
 
 - (BOOL)conformsToProtocol:(Protocol *)aProtocol
@@ -58,6 +65,27 @@
 - (BOOL)respondsToSelector:(SEL)selector
 {
     return ([self methodSignatureForSelector:selector] != nil);
+}
+
+@end
+
+@implementation OCRespondingProtocolMockObject
+
+- (BOOL)respondsToSelector:(SEL)aSelector
+{
+    BOOL required;
+    NSMethodSignature *sig = [self methodSignatureForSelector:aSelector isRequired:&required];
+    return (sig && required) || [self handleSelector:aSelector];
+}
+
+- (void)stopMocking
+{
+    expectationOrderMatters = NO;
+    [stubs release]; stubs = [[NSMutableArray alloc] init];
+    [expectations release]; expectations = [[NSMutableArray alloc] init];
+    [exceptions release]; exceptions = [[NSMutableArray alloc] init];
+    [invocations release]; invocations = [[NSMutableArray alloc] init];
+    [super stopMocking];
 }
 
 @end

--- a/Source/OCMockTests/OCMockObjectProtocolMocksTests.m
+++ b/Source/OCMockTests/OCMockObjectProtocolMocksTests.m
@@ -152,4 +152,26 @@ typedef InterfaceForTypedef* PointerTypedefInterface;
     XCTAssertThrows(OCMProtocolMock(nil));
 }
 
+- (void)testRespondingMockProtocol
+{
+    id mock = [OCMockObject respondingMockForProtocol:@protocol(TestProtocol)];
+    XCTAssertTrue([mock respondsToSelector:@selector(primitiveValue)]);
+    XCTAssertFalse([mock respondsToSelector:@selector(objectValue)]);
+    [[mock expect] objectValue];
+    XCTAssertTrue([mock respondsToSelector:@selector(objectValue)]);
+    [mock objectValue];
+    XCTAssertFalse([mock respondsToSelector:@selector(objectValue)]);
+
+    [[mock expect] objectValue];
+    XCTAssertTrue([mock respondsToSelector:@selector(objectValue)]);
+    [mock stopMocking];
+    XCTAssertFalse([mock respondsToSelector:@selector(objectValue)]);
+
+    [[mock expect] objectValue];
+    [[mock reject] objectValue];
+    XCTAssertTrue([mock respondsToSelector:@selector(objectValue)]);
+    [mock objectValue];
+    XCTAssertTrue([mock respondsToSelector:@selector(objectValue)]);
+}
+
 @end


### PR DESCRIPTION
I ran into an issue recently when I wanted to test a class which has a delegate with a number of optional delegate methods.  The functionality should be tested for both when the delegate implements an optional method and also when it does not.   I could not figure out a way to do this with OCMock other than implementing a slew of individual classes which implement only the desired combination of methods for a particular test, since protocol mocks always return YES from -respondsToSelector: regardless if the method is implemented or not.

The problem is also noted at http://stackoverflow.com/questions/11923942/ocmock-mocking-protocols-with-excluding-optional-methods so it has come up before.  The solution there is to create an object which has state which controls the -respondsToSelector: method, and methods to manipulate that state. I ended up with a similar solution, where I made a special class that was designed to be partial mocked, but then knew about the mock counterpart (using private OCMock APIs), and implemented -respondsToSelector: based on if there were any stubs, expects, or rejects on the partial mock.  This worked pretty well.

However, I thought of a different though similar approach.  This involves a subclass of OCProtocolMockObject instead, which implements -respondsToSelector: for optional methods based on if there are any stubs, expects, or rejects added to the mock.  For required methods, it will return YES always. This is basically the same functionality, but seems to fit in more naturally with OCMock.  A test can simply expect the methods they want called, and -respondsToSelector: will work for those, but not other methods, allowing to test delegates both ways (implementing methods or not).  -reject can be used if the user wants the method to be implemented but still not called.  It is not a nice mock, so unexpected calls should still cause exceptions.  I'm not sure a "nice" version would make any sense, but it wouldn't to be hard to add if my imagination is just missing something.

Does this approach make sense, or are there better ideas, or is there a way to do this currently that I'm missing?
