### PR TITLE
Unregister subclasses from the runtime when they're no longer being mocked.

### DIFF
--- a/Source/OCMock/OCClassMockObject.h
+++ b/Source/OCMock/OCClassMockObject.h
@@ -20,11 +20,13 @@
 {
 	Class               mockedClass;
     Class               originalMetaClass;
+    Class               registeredSubclass;
 }
 
 - (id)initWithClass:(Class)aClass;
 
 - (Class)mockedClass;
+- (Class)registeredSubclass;
 - (Class)mockObjectClass;  // since -class returns the mockedClass
 
 @end

--- a/Source/OCMock/OCClassMockObject.m
+++ b/Source/OCMock/OCClassMockObject.m
@@ -56,6 +56,8 @@
 {
     if(originalMetaClass != nil)
         [self restoreMetaClass];
+    if (registeredSubclass != nil)
+        [self removeDynamicSubclass];
     [super stopMocking];
 }
 
@@ -64,6 +66,12 @@
     OCMSetAssociatedMockForClass(nil, mockedClass);
     object_setClass(mockedClass, originalMetaClass);
     originalMetaClass = nil;
+}
+
+- (void)removeDynamicSubclass
+{
+    objc_disposeClassPair(registeredSubclass);
+    registeredSubclass = nil;
 }
 
 - (void)addStub:(OCMInvocationStub *)aStub
@@ -91,6 +99,7 @@
 
     /* dynamically create a subclass and use its meta class as the meta class for the mocked class */
     Class subclass = OCMCreateSubclass(mockedClass, mockedClass);
+    registeredSubclass = subclass;
     originalMetaClass = object_getClass(mockedClass);
     id newMetaClass = object_getClass(subclass);
 
@@ -190,6 +199,11 @@
 - (Class)class
 {
     return mockedClass;
+}
+
+- (Class)registeredSubclass
+{
+    return registeredSubclass;
 }
 
 - (BOOL)respondsToSelector:(SEL)selector

--- a/Source/OCMock/OCPartialMockObject.m
+++ b/Source/OCMock/OCPartialMockObject.m
@@ -105,6 +105,7 @@
 
     /* dynamically create a subclass and set it as the class of the object */
     Class subclass = OCMCreateSubclass(mockedClass, realObject);
+    registeredSubclass = subclass;
 	object_setClass(realObject, subclass);
 
     /* point forwardInvocation: of the object to the implementation in the mock */

--- a/Source/OCMockTests/OCMockObjectClassMethodMockingTests.m
+++ b/Source/OCMockTests/OCMockObjectClassMethodMockingTests.m
@@ -107,6 +107,18 @@ static NSUInteger initializeCallCount = 0;
     XCTAssertEqualObjects(@"Foo-ClassMethod", [TestClassWithClassMethods foo], @"Should not have stubbed class method.");
 }
 
+- (void)testClassNoLongerRegisteredAfterStopWasCalled
+{
+    id mock = [OCMockObject mockForClass:[TestClassWithClassMethods class]];
+    
+    [[[[mock stub] classMethod] andReturn:@"mocked"] foo];
+    Class registeredSubclass = [mock registeredSubclass];
+    [mock stopMocking];
+    registeredSubclass = objc_getClass(class_getName(registeredSubclass));
+    
+    XCTAssertNil(registeredSubclass, @"Mock subclass should no longer be regstered with runtime.");
+}
+
 - (void)testClassReceivesMethodAgainWhenExpectedCallOccurred
 {
     id mock = [OCMockObject mockForClass:[TestClassWithClassMethods class]];


### PR DESCRIPTION
OCMock created subclasses were still registered with the runtime after the classes were no longer being mocked. This caused test failures with a database that was inspecting the list of registered classes at runtime.