### PR TITLE
Add basic tvOS support with new target and via CocoaPods.

### DIFF
--- a/OCMock.podspec
+++ b/OCMock.podspec
@@ -23,6 +23,7 @@ Pod::Spec.new do |s|
   s.requires_arc          = false
   s.ios.deployment_target = '5.0'
   s.osx.deployment_target = '10.6'
+  s.tvos.deployment_target = '9.0'
    
   s.public_header_files   = ["OCMock.h", "OCMockObject.h", "OCMArg.h", "OCMConstraint.h", 
                               "OCMLocation.h", "OCMMacroState.h", "OCMRecorder.h", 

--- a/Source/OCMock.xcodeproj/project.pbxproj
+++ b/Source/OCMock.xcodeproj/project.pbxproj
@@ -181,6 +181,75 @@
 		2FA28FEAEF9333D2C214DF53 /* NSValue+OCMAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 2FA28896E5EEFD7C2F12C2F8 /* NSValue+OCMAdditions.m */; };
 		3C0FF06A1BAA3FD10021AD20 /* OCMFunctionsPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 03F370CA1BAA1DE800CAD3E8 /* OCMFunctionsPrivate.h */; };
 		3C0FF06B1BAA3FD20021AD20 /* OCMFunctionsPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 03F370CA1BAA1DE800CAD3E8 /* OCMFunctionsPrivate.h */; };
+		817EB1171BD765130047E85A /* OCMockObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 03B3159E146333BF0052CD09 /* OCMockObject.m */; };
+		817EB1181BD765130047E85A /* OCClassMockObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 03B3158C146333BF0052CD09 /* OCClassMockObject.m */; };
+		817EB1191BD765130047E85A /* OCPartialMockObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 03B315AA146333BF0052CD09 /* OCPartialMockObject.m */; };
+		817EB11A1BD765130047E85A /* OCProtocolMockObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 03B315AE146333BF0052CD09 /* OCProtocolMockObject.m */; };
+		817EB11B1BD765130047E85A /* OCMRecorder.m in Sources */ = {isa = PBXBuildFile; fileRef = 03618D82195B553400389166 /* OCMRecorder.m */; };
+		817EB11C1BD765130047E85A /* OCMStubRecorder.m in Sources */ = {isa = PBXBuildFile; fileRef = 03B315A0146333BF0052CD09 /* OCMStubRecorder.m */; };
+		817EB11D1BD765130047E85A /* OCMExpectationRecorder.m in Sources */ = {isa = PBXBuildFile; fileRef = 03C7BF0F195DAB5300A545DD /* OCMExpectationRecorder.m */; };
+		817EB11E1BD765130047E85A /* OCMVerifier.m in Sources */ = {isa = PBXBuildFile; fileRef = 0322DA6819118B4600CACAF1 /* OCMVerifier.m */; };
+		817EB11F1BD765130047E85A /* OCMInvocationMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 2FA28CB1EB14C6B2BE9A20C6 /* OCMInvocationMatcher.m */; };
+		817EB1201BD765130047E85A /* OCMInvocationStub.m in Sources */ = {isa = PBXBuildFile; fileRef = 03C7BF09195DA2F200A545DD /* OCMInvocationStub.m */; };
+		817EB1211BD765130047E85A /* OCMInvocationExpectation.m in Sources */ = {isa = PBXBuildFile; fileRef = 2FA2875564A6AD0510A847A6 /* OCMInvocationExpectation.m */; };
+		817EB1221BD765130047E85A /* OCMRealObjectForwarder.m in Sources */ = {isa = PBXBuildFile; fileRef = 03B315A4146333BF0052CD09 /* OCMRealObjectForwarder.m */; };
+		817EB1231BD765130047E85A /* OCMBlockCaller.m in Sources */ = {isa = PBXBuildFile; fileRef = 03B31590146333BF0052CD09 /* OCMBlockCaller.m */; };
+		817EB1241BD765130047E85A /* OCMBoxedReturnValueProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 03B31592146333BF0052CD09 /* OCMBoxedReturnValueProvider.m */; };
+		817EB1251BD765130047E85A /* OCMExceptionReturnValueProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 03B31596146333BF0052CD09 /* OCMExceptionReturnValueProvider.m */; };
+		817EB1261BD765130047E85A /* OCMIndirectReturnValueProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 03B31598146333BF0052CD09 /* OCMIndirectReturnValueProvider.m */; };
+		817EB1271BD765130047E85A /* OCMNotificationPoster.m in Sources */ = {isa = PBXBuildFile; fileRef = 03B3159A146333BF0052CD09 /* OCMNotificationPoster.m */; };
+		817EB1281BD765130047E85A /* OCMReturnValueProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 03B315A6146333BF0052CD09 /* OCMReturnValueProvider.m */; };
+		817EB1291BD765130047E85A /* OCMLocation.m in Sources */ = {isa = PBXBuildFile; fileRef = 03E98D4A18F308B400522D42 /* OCMLocation.m */; };
+		817EB12A1BD765130047E85A /* OCMMacroState.m in Sources */ = {isa = PBXBuildFile; fileRef = 2FA280987F4EA8A4D79000D0 /* OCMMacroState.m */; };
+		817EB12B1BD765130047E85A /* OCMBlockArgCaller.m in Sources */ = {isa = PBXBuildFile; fileRef = 2FA283D58AA7569D8A5B0C57 /* OCMBlockArgCaller.m */; };
+		817EB12C1BD765130047E85A /* OCObserverMockObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 03B315A8146333BF0052CD09 /* OCObserverMockObject.m */; };
+		817EB12D1BD765130047E85A /* OCMObserverRecorder.m in Sources */ = {isa = PBXBuildFile; fileRef = 03B3159C146333BF0052CD09 /* OCMObserverRecorder.m */; };
+		817EB12E1BD765130047E85A /* OCMArg.m in Sources */ = {isa = PBXBuildFile; fileRef = 03B3158E146333BF0052CD09 /* OCMArg.m */; };
+		817EB12F1BD765130047E85A /* OCMConstraint.m in Sources */ = {isa = PBXBuildFile; fileRef = 03B31594146333BF0052CD09 /* OCMConstraint.m */; };
+		817EB1301BD765130047E85A /* OCMPassByRefSetter.m in Sources */ = {isa = PBXBuildFile; fileRef = 03B315A2146333BF0052CD09 /* OCMPassByRefSetter.m */; };
+		817EB1311BD765130047E85A /* NSInvocation+OCMAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 03B31586146333BF0052CD09 /* NSInvocation+OCMAdditions.m */; };
+		817EB1321BD765130047E85A /* NSMethodSignature+OCMAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 03B31588146333BF0052CD09 /* NSMethodSignature+OCMAdditions.m */; };
+		817EB1331BD765130047E85A /* NSNotificationCenter+OCMAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 03B3158A146333BF0052CD09 /* NSNotificationCenter+OCMAdditions.m */; };
+		817EB1341BD765130047E85A /* NSObject+OCMAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 2FA28991BEFD67DEF2CCF7D2 /* NSObject+OCMAdditions.m */; };
+		817EB1351BD765130047E85A /* NSValue+OCMAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 2FA28896E5EEFD7C2F12C2F8 /* NSValue+OCMAdditions.m */; };
+		817EB1361BD765130047E85A /* OCMFunctions.m in Sources */ = {isa = PBXBuildFile; fileRef = 2FA28C8717BE4B7A89119BA2 /* OCMFunctions.m */; };
+		817EB1371BD765130047E85A /* OCMArgAction.m in Sources */ = {isa = PBXBuildFile; fileRef = 2FA28A7898E1046DE957A035 /* OCMArgAction.m */; };
+		817EB1391BD765130047E85A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F0B9510A1B0080D500942C38 /* Foundation.framework */; };
+		817EB13B1BD765130047E85A /* OCMock.h in Headers */ = {isa = PBXBuildFile; fileRef = 030EF0B814632FD000B04273 /* OCMock.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		817EB13C1BD765130047E85A /* OCMockObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 03B3159D146333BF0052CD09 /* OCMockObject.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		817EB13D1BD765130047E85A /* OCMStubRecorder.h in Headers */ = {isa = PBXBuildFile; fileRef = 03B3159F146333BF0052CD09 /* OCMStubRecorder.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		817EB13E1BD765130047E85A /* OCMArg.h in Headers */ = {isa = PBXBuildFile; fileRef = 03B3158D146333BF0052CD09 /* OCMArg.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		817EB13F1BD765130047E85A /* OCMConstraint.h in Headers */ = {isa = PBXBuildFile; fileRef = 03B31593146333BF0052CD09 /* OCMConstraint.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		817EB1401BD765130047E85A /* OCMRecorder.h in Headers */ = {isa = PBXBuildFile; fileRef = 03618D81195B553400389166 /* OCMRecorder.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		817EB1411BD765130047E85A /* NSNotificationCenter+OCMAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 03B31589146333BF0052CD09 /* NSNotificationCenter+OCMAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		817EB1421BD765130047E85A /* OCMLocation.h in Headers */ = {isa = PBXBuildFile; fileRef = 03E98D4918F308B400522D42 /* OCMLocation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		817EB1431BD765130047E85A /* OCMMacroState.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FA28006D043CBDBBAEF6E3F /* OCMMacroState.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		817EB1441BD765130047E85A /* OCClassMockObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 03B3158B146333BF0052CD09 /* OCClassMockObject.h */; };
+		817EB1451BD765130047E85A /* OCPartialMockObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 03B315A9146333BF0052CD09 /* OCPartialMockObject.h */; };
+		817EB1461BD765130047E85A /* OCProtocolMockObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 03B315AD146333BF0052CD09 /* OCProtocolMockObject.h */; };
+		817EB1471BD765130047E85A /* OCMExpectationRecorder.h in Headers */ = {isa = PBXBuildFile; fileRef = 03C7BF0E195DAB5300A545DD /* OCMExpectationRecorder.h */; };
+		817EB1481BD765130047E85A /* OCMVerifier.h in Headers */ = {isa = PBXBuildFile; fileRef = 0322DA6719118B4600CACAF1 /* OCMVerifier.h */; };
+		817EB1491BD765130047E85A /* OCMInvocationMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FA28CCC33B99D6B658E7AF8 /* OCMInvocationMatcher.h */; };
+		817EB14A1BD765130047E85A /* OCMInvocationStub.h in Headers */ = {isa = PBXBuildFile; fileRef = 03C7BF08195DA2F200A545DD /* OCMInvocationStub.h */; };
+		817EB14B1BD765130047E85A /* OCMInvocationExpectation.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FA288509D545BDBE094BCC8 /* OCMInvocationExpectation.h */; };
+		817EB14C1BD765130047E85A /* OCMRealObjectForwarder.h in Headers */ = {isa = PBXBuildFile; fileRef = 03B315A3146333BF0052CD09 /* OCMRealObjectForwarder.h */; };
+		817EB14D1BD765130047E85A /* OCMBlockCaller.h in Headers */ = {isa = PBXBuildFile; fileRef = 03B3158F146333BF0052CD09 /* OCMBlockCaller.h */; };
+		817EB14E1BD765130047E85A /* OCMBoxedReturnValueProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 03B31591146333BF0052CD09 /* OCMBoxedReturnValueProvider.h */; };
+		817EB14F1BD765130047E85A /* OCMExceptionReturnValueProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 03B31595146333BF0052CD09 /* OCMExceptionReturnValueProvider.h */; };
+		817EB1501BD765130047E85A /* OCMIndirectReturnValueProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 03B31597146333BF0052CD09 /* OCMIndirectReturnValueProvider.h */; };
+		817EB1511BD765130047E85A /* OCMNotificationPoster.h in Headers */ = {isa = PBXBuildFile; fileRef = 03B31599146333BF0052CD09 /* OCMNotificationPoster.h */; };
+		817EB1521BD765130047E85A /* OCMReturnValueProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 03B315A5146333BF0052CD09 /* OCMReturnValueProvider.h */; };
+		817EB1531BD765130047E85A /* OCMFunctionsPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 03F370CA1BAA1DE800CAD3E8 /* OCMFunctionsPrivate.h */; };
+		817EB1541BD765130047E85A /* OCObserverMockObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 03B315A7146333BF0052CD09 /* OCObserverMockObject.h */; };
+		817EB1551BD765130047E85A /* OCMObserverRecorder.h in Headers */ = {isa = PBXBuildFile; fileRef = 03B3159B146333BF0052CD09 /* OCMObserverRecorder.h */; };
+		817EB1561BD765130047E85A /* OCMPassByRefSetter.h in Headers */ = {isa = PBXBuildFile; fileRef = 03B315A1146333BF0052CD09 /* OCMPassByRefSetter.h */; };
+		817EB1571BD765130047E85A /* NSInvocation+OCMAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 03B31585146333BF0052CD09 /* NSInvocation+OCMAdditions.h */; };
+		817EB1581BD765130047E85A /* NSMethodSignature+OCMAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 03B31587146333BF0052CD09 /* NSMethodSignature+OCMAdditions.h */; };
+		817EB1591BD765130047E85A /* NSObject+OCMAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FA28C5F4A475BEC0C28BDC3 /* NSObject+OCMAdditions.h */; };
+		817EB15A1BD765130047E85A /* NSValue+OCMAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FA286EAC1682979C696D4D6 /* NSValue+OCMAdditions.h */; };
+		817EB15B1BD765130047E85A /* OCMFunctions.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FA28EC49F6C59B940AE6D00 /* OCMFunctions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		817EB15C1BD765130047E85A /* OCMBlockArgCaller.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FA2891034E7B73AA3511D17 /* OCMBlockArgCaller.h */; };
+		817EB15D1BD765130047E85A /* OCMArgAction.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FA2833B48908EAD36444671 /* OCMArgAction.h */; };
 		817EB1661BD7674D0047E85A /* OCMFunctionsPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 03F370CA1BAA1DE800CAD3E8 /* OCMFunctionsPrivate.h */; };
 		D31108BA1828DB8700737925 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = D31108B81828DB8700737925 /* InfoPlist.strings */; };
 		D31108C41828DBD600737925 /* OCMockObjectPartialMocksTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 03AC5C1416DF9FA500D82ECD /* OCMockObjectPartialMocksTests.m */; };
@@ -375,6 +444,7 @@
 		2FA28EC49F6C59B940AE6D00 /* OCMFunctions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OCMFunctions.h; sourceTree = "<group>"; };
 		2FA28EDBF243639C57F88A1B /* OCMArgTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OCMArgTests.m; sourceTree = "<group>"; };
 		2FA28EE3142412BD601026EF /* OCMockObjectDynamicPropertyMockingTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OCMockObjectDynamicPropertyMockingTests.m; sourceTree = "<group>"; };
+		817EB1621BD765130047E85A /* OCMock.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = OCMock.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D31108AD1828DB8700737925 /* OCMockLibTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OCMockLibTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D31108B71828DB8700737925 /* OCMockLibTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "OCMockLibTests-Info.plist"; sourceTree = "<group>"; };
 		D31108B91828DB8700737925 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -407,6 +477,14 @@
 				03C7BF1619606E7A00A545DD /* XCTest.framework in Frameworks */,
 				03C7BF1719606EFD00A545DD /* OCMock.framework in Frameworks */,
 				03565A4E18F05877003AE91E /* OCHamcrest.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		817EB1381BD765130047E85A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				817EB1391BD765130047E85A /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -450,6 +528,7 @@
 				D31108AD1828DB8700737925 /* OCMockLibTests.xctest */,
 				03565A3118F0566E003AE91E /* OCMockTests.xctest */,
 				F0B950F11B0080BE00942C38 /* OCMock.framework */,
+				817EB1621BD765130047E85A /* OCMock.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -781,6 +860,48 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		817EB13A1BD765130047E85A /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				817EB13B1BD765130047E85A /* OCMock.h in Headers */,
+				817EB13C1BD765130047E85A /* OCMockObject.h in Headers */,
+				817EB13D1BD765130047E85A /* OCMStubRecorder.h in Headers */,
+				817EB13E1BD765130047E85A /* OCMArg.h in Headers */,
+				817EB13F1BD765130047E85A /* OCMConstraint.h in Headers */,
+				817EB1401BD765130047E85A /* OCMRecorder.h in Headers */,
+				817EB1411BD765130047E85A /* NSNotificationCenter+OCMAdditions.h in Headers */,
+				817EB1421BD765130047E85A /* OCMLocation.h in Headers */,
+				817EB1431BD765130047E85A /* OCMMacroState.h in Headers */,
+				817EB1441BD765130047E85A /* OCClassMockObject.h in Headers */,
+				817EB1451BD765130047E85A /* OCPartialMockObject.h in Headers */,
+				817EB1461BD765130047E85A /* OCProtocolMockObject.h in Headers */,
+				817EB1471BD765130047E85A /* OCMExpectationRecorder.h in Headers */,
+				817EB1481BD765130047E85A /* OCMVerifier.h in Headers */,
+				817EB1491BD765130047E85A /* OCMInvocationMatcher.h in Headers */,
+				817EB14A1BD765130047E85A /* OCMInvocationStub.h in Headers */,
+				817EB14B1BD765130047E85A /* OCMInvocationExpectation.h in Headers */,
+				817EB14C1BD765130047E85A /* OCMRealObjectForwarder.h in Headers */,
+				817EB14D1BD765130047E85A /* OCMBlockCaller.h in Headers */,
+				817EB14E1BD765130047E85A /* OCMBoxedReturnValueProvider.h in Headers */,
+				817EB14F1BD765130047E85A /* OCMExceptionReturnValueProvider.h in Headers */,
+				817EB1501BD765130047E85A /* OCMIndirectReturnValueProvider.h in Headers */,
+				817EB1511BD765130047E85A /* OCMNotificationPoster.h in Headers */,
+				817EB1521BD765130047E85A /* OCMReturnValueProvider.h in Headers */,
+				817EB1531BD765130047E85A /* OCMFunctionsPrivate.h in Headers */,
+				817EB1541BD765130047E85A /* OCObserverMockObject.h in Headers */,
+				817EB1551BD765130047E85A /* OCMObserverRecorder.h in Headers */,
+				817EB1561BD765130047E85A /* OCMPassByRefSetter.h in Headers */,
+				817EB1571BD765130047E85A /* NSInvocation+OCMAdditions.h in Headers */,
+				817EB1581BD765130047E85A /* NSMethodSignature+OCMAdditions.h in Headers */,
+				817EB1591BD765130047E85A /* NSObject+OCMAdditions.h in Headers */,
+				817EB15A1BD765130047E85A /* NSValue+OCMAdditions.h in Headers */,
+				817EB15B1BD765130047E85A /* OCMFunctions.h in Headers */,
+				817EB15C1BD765130047E85A /* OCMBlockArgCaller.h in Headers */,
+				817EB15D1BD765130047E85A /* OCMArgAction.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		F0B950EE1B0080BE00942C38 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -880,6 +1001,24 @@
 			productReference = 03565A3118F0566E003AE91E /* OCMockTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		817EB1151BD765130047E85A /* OCMock tvOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 817EB15F1BD765130047E85A /* Build configuration list for PBXNativeTarget "OCMock tvOS" */;
+			buildPhases = (
+				817EB1161BD765130047E85A /* Sources */,
+				817EB1381BD765130047E85A /* Frameworks */,
+				817EB13A1BD765130047E85A /* Headers */,
+				817EB15E1BD765130047E85A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "OCMock tvOS";
+			productName = "OCMock iOS";
+			productReference = 817EB1621BD765130047E85A /* OCMock.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 		D31108AC1828DB8700737925 /* OCMockLibTests */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = D31108C01828DB8700737925 /* Build configuration list for PBXNativeTarget "OCMockLibTests" */;
@@ -954,6 +1093,7 @@
 				030EF0DB14632FF700B04273 /* OCMockLib */,
 				D31108AC1828DB8700737925 /* OCMockLibTests */,
 				F0B950F01B0080BE00942C38 /* OCMock iOS */,
+				817EB1151BD765130047E85A /* OCMock tvOS */,
 			);
 		};
 /* End PBXProject section */
@@ -972,6 +1112,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				03565A3818F0566F003AE91E /* InfoPlist.strings in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		817EB15E1BD765130047E85A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1111,6 +1258,46 @@
 				2FA2839F33289795284C32FB /* OCMockObjectTests.m in Sources */,
 				2FA28AB33F01A7D980F2C705 /* OCMockObjectDynamicPropertyMockingTests.m in Sources */,
 				031E50581BB4A56300E257C3 /* OCMBoxedReturnValueProviderTests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		817EB1161BD765130047E85A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				817EB1171BD765130047E85A /* OCMockObject.m in Sources */,
+				817EB1181BD765130047E85A /* OCClassMockObject.m in Sources */,
+				817EB1191BD765130047E85A /* OCPartialMockObject.m in Sources */,
+				817EB11A1BD765130047E85A /* OCProtocolMockObject.m in Sources */,
+				817EB11B1BD765130047E85A /* OCMRecorder.m in Sources */,
+				817EB11C1BD765130047E85A /* OCMStubRecorder.m in Sources */,
+				817EB11D1BD765130047E85A /* OCMExpectationRecorder.m in Sources */,
+				817EB11E1BD765130047E85A /* OCMVerifier.m in Sources */,
+				817EB11F1BD765130047E85A /* OCMInvocationMatcher.m in Sources */,
+				817EB1201BD765130047E85A /* OCMInvocationStub.m in Sources */,
+				817EB1211BD765130047E85A /* OCMInvocationExpectation.m in Sources */,
+				817EB1221BD765130047E85A /* OCMRealObjectForwarder.m in Sources */,
+				817EB1231BD765130047E85A /* OCMBlockCaller.m in Sources */,
+				817EB1241BD765130047E85A /* OCMBoxedReturnValueProvider.m in Sources */,
+				817EB1251BD765130047E85A /* OCMExceptionReturnValueProvider.m in Sources */,
+				817EB1261BD765130047E85A /* OCMIndirectReturnValueProvider.m in Sources */,
+				817EB1271BD765130047E85A /* OCMNotificationPoster.m in Sources */,
+				817EB1281BD765130047E85A /* OCMReturnValueProvider.m in Sources */,
+				817EB1291BD765130047E85A /* OCMLocation.m in Sources */,
+				817EB12A1BD765130047E85A /* OCMMacroState.m in Sources */,
+				817EB12B1BD765130047E85A /* OCMBlockArgCaller.m in Sources */,
+				817EB12C1BD765130047E85A /* OCObserverMockObject.m in Sources */,
+				817EB12D1BD765130047E85A /* OCMObserverRecorder.m in Sources */,
+				817EB12E1BD765130047E85A /* OCMArg.m in Sources */,
+				817EB12F1BD765130047E85A /* OCMConstraint.m in Sources */,
+				817EB1301BD765130047E85A /* OCMPassByRefSetter.m in Sources */,
+				817EB1311BD765130047E85A /* NSInvocation+OCMAdditions.m in Sources */,
+				817EB1321BD765130047E85A /* NSMethodSignature+OCMAdditions.m in Sources */,
+				817EB1331BD765130047E85A /* NSNotificationCenter+OCMAdditions.m in Sources */,
+				817EB1341BD765130047E85A /* NSObject+OCMAdditions.m in Sources */,
+				817EB1351BD765130047E85A /* NSValue+OCMAdditions.m in Sources */,
+				817EB1361BD765130047E85A /* OCMFunctions.m in Sources */,
+				817EB1371BD765130047E85A /* OCMArgAction.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1438,6 +1625,80 @@
 			};
 			name = Release;
 		};
+		817EB1601BD765130047E85A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				INFOPLIST_FILE = "OCMock/OCMock-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mulle-kybernetik.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_NAME = OCMock;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		817EB1611BD765130047E85A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				INFOPLIST_FILE = "OCMock/OCMock-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mulle-kybernetik.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_NAME = OCMock;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
 		D31108C11828DB8700737925 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1617,6 +1878,15 @@
 			buildConfigurations = (
 				03565A3F18F0566F003AE91E /* Debug */,
 				03565A4018F0566F003AE91E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		817EB15F1BD765130047E85A /* Build configuration list for PBXNativeTarget "OCMock tvOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				817EB1601BD765130047E85A /* Debug */,
+				817EB1611BD765130047E85A /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Source/OCMock.xcodeproj/xcshareddata/xcschemes/OCMock tvOS.xcscheme
+++ b/Source/OCMock.xcodeproj/xcshareddata/xcschemes/OCMock tvOS.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0710"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "817EB1151BD765130047E85A"
+               BuildableName = "OCMock.framework"
+               BlueprintName = "OCMock tvOS"
+               ReferencedContainer = "container:OCMock.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "817EB1151BD765130047E85A"
+            BuildableName = "OCMock.framework"
+            BlueprintName = "OCMock tvOS"
+            ReferencedContainer = "container:OCMock.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "817EB1151BD765130047E85A"
+            BuildableName = "OCMock.framework"
+            BlueprintName = "OCMock tvOS"
+            ReferencedContainer = "container:OCMock.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Tools/build.rb
+++ b/Tools/build.rb
@@ -50,6 +50,13 @@ class Builder
         @worker.run("mkdir -p #{iosproductdir}")
         @worker.run("cp -R #{@env.symroot}/Release/libOCMock.a #{iosproductdir}")
         @worker.run("cp -R #{@env.symroot}/Release-iphoneos/OCMock #{iosproductdir}")
+        
+        @worker.run("xcodebuild -project OCMock.xcodeproj -target 'OCMock tvOS' -sdk appletvos OBJROOT=#{@env.objroot} SYMROOT=#{@env.symroot}")
+        @worker.run("xcodebuild -project OCMock.xcodeproj -target 'OCMock tvOS' -sdk appletvsimulator OBJROOT=#{@env.objroot} SYMROOT=#{@env.symroot}")
+        tvosproductdir = "#{@env.productdir}/tvOS"                                           
+        @worker.run("mkdir -p #{tvosproductdir}")
+        @worker.run("cp -R #{@env.symroot}/Release-appletvos/OCMock.framework #{tvosproductdir}")
+        @worker.run("lipo -create -output #{tvosproductdir}/OCMock.framework/OCMock #{@env.symroot}/Release-appletvos/OCMock.framework/OCMock #{@env.symroot}/Release-appletvsimulator/OCMock.framework/OCMock")
     end
 
     def createPackage(packagename, volumename)    


### PR DESCRIPTION
- Based on existing `OCMock iOS` target aka dynamic framework
- Relies on the same Info.plist as any other Framework
- Same product name
- Same everything else
- Biggest difference - it has `appletvos` set as the base SDK, which is going to work only when building with Xcode 7.1 (any beta)

I don't think there is a need to add static library support, simply due:
- tvOS supports dynamic frameworks since day 1
- Frameworks have built-in module support, which is much better approach compared to prefix headers or C-style imports.

Should somewhat address #257.