### PR TITLE
Fixed asan crashing when using notificationWithName:object: in an ARC project

### DIFF
--- a/Source/OCMock/OCMObserverRecorder.h
+++ b/Source/OCMock/OCMObserverRecorder.h
@@ -21,7 +21,9 @@
 	NSNotification *recordedNotification;
 }
 
-- (void)notificationWithName:(NSString *)name object:(id)sender;
+- (NSNotification *)notificationWithName:(NSString *)name object:(id)sender;
+
+- (NSNotification *)notificationWithName:(NSString *)name object:(id)sender userInfo:(NSDictionary *)userInfo;
 
 - (BOOL)matchesNotification:(NSNotification *)aNotification;
 

--- a/Source/OCMock/OCMObserverRecorder.m
+++ b/Source/OCMock/OCMObserverRecorder.m
@@ -39,14 +39,16 @@
 
 #pragma mark  Recording
 
-- (void)notificationWithName:(NSString *)name object:(id)sender
+- (NSNotification *)notificationWithName:(NSString *)name object:(id)sender
 {
 	recordedNotification = [[NSNotification notificationWithName:name object:sender] retain];
+	return recordedNotification;
 }
 
-- (void)notificationWithName:(NSString *)name object:(id)sender userInfo:(NSDictionary *)userInfo
+- (NSNotification *)notificationWithName:(NSString *)name object:(id)sender userInfo:(NSDictionary *)userInfo
 {
 	recordedNotification = [[NSNotification notificationWithName:name object:sender userInfo:userInfo] retain];
+	return recordedNotification;
 }
 
 

--- a/Source/OCMock/OCMObserverRecorder.m
+++ b/Source/OCMock/OCMObserverRecorder.m
@@ -42,13 +42,13 @@
 - (NSNotification *)notificationWithName:(NSString *)name object:(id)sender
 {
 	recordedNotification = [[NSNotification notificationWithName:name object:sender] retain];
-	return recordedNotification;
+	return nil;
 }
 
 - (NSNotification *)notificationWithName:(NSString *)name object:(id)sender userInfo:(NSDictionary *)userInfo
 {
 	recordedNotification = [[NSNotification notificationWithName:name object:sender userInfo:userInfo] retain];
-	return recordedNotification;
+	return nil;
 }
 
 

--- a/Source/OCMock/OCObserverMockObject.h
+++ b/Source/OCMock/OCObserverMockObject.h
@@ -38,6 +38,6 @@
 // internal use
 
 - (void)autoRemoveFromCenter:(NSNotificationCenter *)aCenter;
-- (void)notificationWithName:(NSString *)name object:(id)sender;
+- (NSNotification *)notificationWithName:(NSString *)name object:(id)sender;
 
 @end

--- a/Source/OCMock/OCObserverMockObject.m
+++ b/Source/OCMock/OCObserverMockObject.m
@@ -98,9 +98,9 @@
 
 #pragma mark  Receiving recording requests via macro
 
-- (void)notificationWithName:(NSString *)name object:(id)sender
+- (NSNotification *)notificationWithName:(NSString *)name object:(id)sender
 {
-    [[self expect] notificationWithName:name object:sender];
+    return [[self expect] notificationWithName:name object:sender];
 }
 
 


### PR DESCRIPTION
OCMObserverRecorder.h and OCObserverMockObject.h are not public headers, so the only headers available that describe the ```notificationWithName:object:``` method are in NSNotification.h. The methods described in NSNotification.h returns an NSNotification object, and since those have a return value, ARC adds an implicit retain when making calls like  ```[[someObserverMock expect] notificationWithName:@"some name" object:someObj]```. If you run a test that has code like this with Xcode's address sanitizer enabled, asan sees this as an issue and then attempts to break and notify you about it. In doing this, it goes to get some debug info about the return value of this method call and ends up de-referencing a nil pointer which crashes the test with EXC_BAD_ACCESS.

There are a few solutions to this that I see:
1. Exposing all of the appropriate headers - This will work, but then people upgrading will likely get compile warnings about multiple selectors being found called ```notificationWithName:object:``` with different return values (fix would just be to do a cast).
2. Change the existing methods to just return the NSNotification object created - This is the solution I went with because 1) for most people this should required no code changes on update 2) updates the method signature to better reflect its name (methods named objectWithArgument: on first glance look like a getter/convenience initializer and should probably return something)