### PR TITLE
Fix unit test warnings.

### DIFF
--- a/Source/OCMockTests/OCMockObjectTests.m
+++ b/Source/OCMockTests/OCMockObjectTests.m
@@ -187,8 +187,8 @@ static NSString *TestNotification = @"TestNotification";
 
 - (void)testAcceptsStubbedMethodWithNilArgument
 {
-	[[mock stub] hasSuffix:nil];
-	[mock hasSuffix:nil];
+	[[mock stub] uppercaseStringWithLocale:nil];
+	[mock uppercaseStringWithLocale:nil];
 }
 
 - (void)testRaisesExceptionWhenMethodWithWrongArgumentIsCalled


### PR DESCRIPTION
Replace -hasSuffix: which doesn't allow a nil argument with -uppercaseStringWithLocale: which does.