### PR TITLE
Use latest SDK available when building a deployment package.

### DIFF
--- a/Tools/build.rb
+++ b/Tools/build.rb
@@ -43,8 +43,9 @@ class Builder
         osxproductdir = "#{@env.productdir}/OSX"                                        
         @worker.run("mkdir -p #{osxproductdir}")
         @worker.run("cp -R #{@env.symroot}/Release/OCMock.framework #{osxproductdir}")
-        @worker.run("xcodebuild -project OCMock.xcodeproj -target OCMockLib -sdk iphoneos8.2 OBJROOT=#{@env.objroot} SYMROOT=#{@env.symroot}")
-        @worker.run("xcodebuild -project OCMock.xcodeproj -target OCMockLib -sdk iphonesimulator8.2 OBJROOT=#{@env.objroot} SYMROOT=#{@env.symroot}")
+        
+        @worker.run("xcodebuild -project OCMock.xcodeproj -target OCMockLib -sdk iphoneos OBJROOT=#{@env.objroot} SYMROOT=#{@env.symroot}")
+        @worker.run("xcodebuild -project OCMock.xcodeproj -target OCMockLib -sdk iphonesimulator OBJROOT=#{@env.objroot} SYMROOT=#{@env.symroot}")
         @worker.run("lipo -create -output #{@env.symroot}/Release/libOCMock.a #{@env.symroot}/Release-*/libOCMock.a")
         iosproductdir = "#{@env.productdir}/iOS"                                           
         @worker.run("mkdir -p #{iosproductdir}")


### PR DESCRIPTION
Latest few releases of Xcode have a single SDK bundled for iOS inside of it thus making `iphonesimulator`, `iphoneos` without version specified use the one and only available SDK version.

I still get to test this with multiple SDK versions on the same platform (would love to test on older version of Xcode, but forgot which one had 2 SDKs simultaneously)...