### PR TITLE
Fix race condition where the method returns while the array is…

### DIFF
--- a/Source/OCMock/OCMockObject.m
+++ b/Source/OCMock/OCMockObject.m
@@ -218,9 +218,9 @@
 
 - (void)verifyInvocation:(OCMInvocationMatcher *)matcher atLocation:(OCMLocation *)location
 {
-    for(NSInvocation *invocation in invocations)
+    for(int i = 0; i < [invocations count]; i++)
     {
-        if([matcher matchesInvocation:invocation])
+        if([matcher matchesInvocation:invocations[i]])
             return;
     }
     NSString *description = [NSString stringWithFormat:@"%@: Method %@ was not invoked.",


### PR DESCRIPTION
… being enumarated


```
failed: caught "NSGenericException", "*** Collection <__NSArrayM: 0x7fc48362c5f0> was mutated while being enumerated."
(
	0   CoreFoundation                      0x000000010f375c65 __exceptionPreprocess + 165
	1   libobjc.A.dylib                     0x000000010d70ebb7 objc_exception_throw + 45
	2   CoreFoundation                      0x000000010f3755c4 __NSFastEnumerationMutationHandler + 132
	3   UberUITests                         0x0000000117ba2921 -[OCMockObject verifyInvocation:atLocation:] + 170
	4   UberUITests                         0x0000000117ba1f53 -[OCMVerifier forwardInvocation:] + 116
	5   CoreFoundation                      0x000000010f2d2f4f ___forwarding___ + 495
	6   CoreFoundation                      0x000000010f2d2cd8 _CF_forwarding_prep_0 + 120
```