### PR TITLE
Remove mocked subclasses from the runtime once the mocked object is d…

### DIFF
--- a/Source/OCMock/OCClassMockObject.m
+++ b/Source/OCMock/OCClassMockObject.m
@@ -54,8 +54,15 @@
 
 - (void)stopMocking
 {
-    if(originalMetaClass != nil)
+    if(originalMetaClass != nil) {
+        const char *mockedSubclassName = object_getClassName([self class]);
+        if (mockedSubclassName) {
+            Class mockedSubclass = NSClassFromString([NSString stringWithUTF8String:mockedSubclassName]);
+            objc_disposeClassPair(mockedSubclass);
+        }
+        
         [self restoreMetaClass];
+    }
     [super stopMocking];
 }
 

--- a/Source/OCMock/OCPartialMockObject.m
+++ b/Source/OCMock/OCPartialMockObject.m
@@ -76,10 +76,12 @@
 {
     if(realObject != nil)
     {
+        Class partialMockClass = object_getClass(realObject);
         OCMSetAssociatedMockForObject(nil, realObject);
         object_setClass(realObject, [self mockedClass]);
         [realObject release];
         realObject = nil;
+        objc_disposeClassPair(partialMockClass);
     }
     [super stopMocking];
 }


### PR DESCRIPTION
…e-allocated or -stopMocking is called.