### PR TITLE
Fix verifyWithDelay interval precision

### DIFF
--- a/Source/OCMock/OCMockObject.m
+++ b/Source/OCMock/OCMockObject.m
@@ -203,7 +203,7 @@
             break;
         [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:step]];
         delay -= step;
-        step *= 2;
+        step = MIN(step * 2, delay);
     }
     [self verifyAtLocation:location];
 }

--- a/Source/OCMockTests/OCMockObjectTests.m
+++ b/Source/OCMockTests/OCMockObjectTests.m
@@ -863,6 +863,22 @@ static NSString *TestNotification = @"TestNotification";
 	XCTAssertThrows([mock verifyWithDelay:0.1], @"Should have raised an exception because method was not called.");
 }
 
+- (void)testFailsTestsAfterGivenDelayAccurately
+{
+  [[mock expect] lowercaseString];
+  NSTimeInterval delay = 1;
+  CGFloat toleranceRate = 0.05;
+  NSDate *startDate;
+  @try {
+    startDate = [NSDate date];
+    [mock verifyWithDelay:delay];
+  }
+  @catch (NSException *exception) {
+    NSTimeInterval interval = [[NSDate date] timeIntervalSinceDate:startDate];
+    XCTAssertEqualWithAccuracy(interval, delay, delay * toleranceRate, @"Delay interval check is not precise enough");
+  }
+}
+
 // --------------------------------------------------------------------------------------
 //	ordered expectations
 // --------------------------------------------------------------------------------------


### PR DESCRIPTION
Currently OCMockObject checks if expectations fulfilled with increasing interval steps. This causes OCMock to wait more than given verification delay because current code does not check if next step interval is greater than remaining interval. 

PR contains the fix and a test case for it. You can verify the problem via reverting the change and running the test case.