### PR TITLE
Added modern syntax for reject

### DIFF
--- a/Source/Changes.txt
+++ b/Source/Changes.txt
@@ -8,6 +8,7 @@ OCMock 3.2.1 (2016-01-13)
 * Disposing dynamically generated subclasses after use (David Stites)
 * Build script now signs frameworks in releases. The signing identity can
   be changed in the script.
+* Added modern syntax for reject (Piotr Tobolski)
 
 
 OCMock 3.2 (2015-10-03)

--- a/Source/OCMock/OCMMacroState.h
+++ b/Source/OCMock/OCMMacroState.h
@@ -33,6 +33,9 @@
 + (void)beginExpectMacro;
 + (OCMStubRecorder *)endExpectMacro;
 
++ (void)beginRejectMacro;
++ (OCMStubRecorder *)endRejectMacro;
+
 + (void)beginVerifyMacroAtLocation:(OCMLocation *)aLocation;
 + (void)endVerifyMacro;
 

--- a/Source/OCMock/OCMMacroState.m
+++ b/Source/OCMock/OCMMacroState.m
@@ -54,6 +54,19 @@ static OCMMacroState *globalState;
 }
 
 
++ (void)beginRejectMacro
+{
+    OCMExpectationRecorder *recorder = [[[OCMExpectationRecorder alloc] init] autorelease];
+    [recorder never];
+    globalState = [[[OCMMacroState alloc] initWithRecorder:recorder] autorelease];
+}
+
++ (OCMStubRecorder *)endRejectMacro
+{
+    return [self endStubMacro];
+}
+
+
 + (void)beginVerifyMacroAtLocation:(OCMLocation *)aLocation
 {
     OCMVerifier *recorder = [[[OCMVerifier alloc] init] autorelease];

--- a/Source/OCMock/OCMock.h
+++ b/Source/OCMock/OCMock.h
@@ -56,6 +56,15 @@
     ); \
 })
 
+#define OCMReject(invocation) \
+({ \
+    _OCMSilenceWarnings( \
+        [OCMMacroState beginRejectMacro]; \
+        invocation; \
+        [OCMMacroState endRejectMacro]; \
+    ); \
+})
+
 #define ClassMethod(invocation) \
     _OCMSilenceWarnings( \
         [[OCMMacroState globalState] switchToClassMethod]; \

--- a/Source/OCMockTests/OCMockObjectMacroTests.m
+++ b/Source/OCMockTests/OCMockObjectMacroTests.m
@@ -268,6 +268,18 @@
 }
 
 
+- (void)testSetsUpReject
+{
+    id mock = OCMClassMock([TestClassForMacroTesting class]);
+
+    OCMReject([mock stringValue]);
+
+    XCTAssertNoThrow([mock verify], @"Should have accepted invocation rejected method not being invoked");
+    XCTAssertThrows([mock stringValue], @"Should have complained during rejected method being invoked");
+    XCTAssertThrows([mock verify], @"Should have complained about rejected method being invoked");
+}
+
+
 - (void)testShouldNotReportErrorWhenMethodWasInvoked
 {
     id mock = OCMClassMock([NSString class]);


### PR DESCRIPTION
Added macro OCMReject that works similar to OCMStub and OCMExpect. It was missing for a long time. It is a lot easier to read.

I've seen in the documentation that it should be added after further quantifiers are added but it haven't been done in over a year so I thought that it would be useful to add this modern syntax with current functionality.