### PR TITLE
+[OCMArg setTo:] crashes if invoked with NULL

### DIFF
--- a/Source/OCMock/OCMPassByRefSetter.m
+++ b/Source/OCMock/OCMPassByRefSetter.m
@@ -37,10 +37,14 @@
 
 - (void)handleArgument:(id)arg
 {
-    if([value isKindOfClass:[NSValue class]])
-        [(NSValue *)value getValue:[arg pointerValue]];
-    else
-        *(id *)[arg pointerValue] = value;
+    void *pointerValue = [arg pointerValue];
+    if(pointerValue != NULL)
+    {
+        if([value isKindOfClass:[NSValue class]])
+            [(NSValue *)value getValue:pointerValue];
+        else
+            *(id *)pointerValue = value;
+    }
 }
 
 @end

--- a/Source/OCMockTests/OCMockObjectTests.m
+++ b/Source/OCMockTests/OCMockObjectTests.m
@@ -106,6 +106,25 @@ TestOpaque myOpaque;
 @end
 
 
+@interface TestClassWithByReferenceMethod : NSObject
+
+- (void)returnValuesInObjectPointer:(id *)objectPointer booleanPointer:(BOOL *)booleanPointer;
+
+@end
+
+@implementation TestClassWithByReferenceMethod
+
+- (void)returnValuesInObjectPointer:(id *)objectPointer booleanPointer:(BOOL *)booleanPointer
+{
+    if(objectPointer != NULL)
+        *objectPointer = [[NSObject alloc] init];
+    if(booleanPointer != NULL)
+        *booleanPointer = NO;
+}
+
+@end
+
+
 @interface NotificationRecorderForTesting : NSObject
 {
 	@public
@@ -634,6 +653,15 @@ static NSString *TestNotification = @"TestNotification";
 
     XCTAssertEqual(1234, actualValue, @"Should have returned value via pass by ref argument.");
 
+}
+
+
+- (void)testReturnsValuesInNullPassByReferenceArguments
+{
+    mock = OCMClassMock([TestClassWithByReferenceMethod class]);
+    OCMStub([mock returnValuesInObjectPointer:[OCMArg setTo:nil] booleanPointer:[OCMArg setToValue:@NO]]);
+    [mock returnValuesInObjectPointer:NULL booleanPointer:NULL];
+    OCMVerify([mock returnValuesInObjectPointer:NULL booleanPointer:NULL]);
 }
 
 


### PR DESCRIPTION
OCMock 3.2.1 introduced a bug where something like this crashes.
OCMStub([mockFileManager createSymbolicLinkAtURL:OCMOCK_ANY withDestinationURL:OCMOCK_ANY error:[OCMArg setTo:nil]]).andReturn(YES);
[mockFileManager createSymbolicLinkAtURL:symlinkFile withDestinationURL:symlinkDestination error:NULL];

Fix it by checking for NULL in OCMPassByRefSetter.