### PR TITLE
Add option to invoke block args asynchronously

### DIFF
--- a/Source/OCMock/OCMArg.h
+++ b/Source/OCMock/OCMArg.h
@@ -38,6 +38,8 @@
 + (void *)setToValue:(NSValue *)value;
 + (id)invokeBlock;
 + (id)invokeBlockWithArgs:(id)first,... NS_REQUIRES_NIL_TERMINATION;
++ (id)invokeBlockAsync;
++ (id)invokeBlockAsyncWithArgs:(id)first,... NS_REQUIRES_NIL_TERMINATION;
 
 + (id)defaultValue;
 

--- a/Source/OCMock/OCMArg.m
+++ b/Source/OCMock/OCMArg.m
@@ -113,7 +113,34 @@
         va_end(args);
     }
     return [[[OCMBlockArgCaller alloc] initWithBlockArguments:params] autorelease];
-    
+}
+
++ (id)invokeBlockAsync
+{
+    OCMBlockArgCaller *blockArgCaller = [[[OCMBlockArgCaller alloc] init] autorelease];
+    blockArgCaller.async = YES;
+    return blockArgCaller;
+}
+
++ (id)invokeBlockAsyncWithArgs:(id)first,... NS_REQUIRES_NIL_TERMINATION
+{
+
+    NSMutableArray *params = [NSMutableArray array];
+    va_list args;
+    if(first)
+    {
+        [params addObject:first];
+        va_start(args, first);
+        id obj;
+        while((obj = va_arg(args, id)))
+        {
+            [params addObject:obj];
+        }
+        va_end(args);
+    }
+    OCMBlockArgCaller *blockArgCaller = [[[OCMBlockArgCaller alloc] initWithBlockArguments:params] autorelease];
+    blockArgCaller.async = YES;
+    return blockArgCaller;
 }
 
 + (id)defaultValue

--- a/Source/OCMock/OCMBlockArgCaller.h
+++ b/Source/OCMock/OCMBlockArgCaller.h
@@ -21,6 +21,8 @@
     NSArray *arguments;
 }
 
+@property (nonatomic) BOOL async;
+
 - (instancetype)initWithBlockArguments:(NSArray *)someArgs;
 
 @end

--- a/Source/OCMock/OCMBlockArgCaller.m
+++ b/Source/OCMock/OCMBlockArgCaller.m
@@ -45,8 +45,18 @@
 {
     if(aBlock)
     {
-        NSInvocation *inv = [NSInvocation invocationForBlock:aBlock withArguments:arguments];
-        [inv invokeWithTarget:aBlock];
+        if(self.async)
+        {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                NSInvocation *inv = [NSInvocation invocationForBlock:aBlock withArguments:arguments];
+                [inv invokeWithTarget:aBlock];
+            });
+        }
+        else
+        {
+            NSInvocation *inv = [NSInvocation invocationForBlock:aBlock withArguments:arguments];
+            [inv invokeWithTarget:aBlock];
+        }
     }
 }
 

--- a/Source/OCMockTests/OCMockObjectTests.m
+++ b/Source/OCMockTests/OCMockObjectTests.m
@@ -787,7 +787,7 @@ static NSString *TestNotification = @"TestNotification";
     }];
     XCTAssertFalse(blockWasInvoked, @"Should not have invoked the block before the run loop.");
 
-    [[NSRunLoop mainRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:.01]];
+    [[NSRunLoop mainRunLoop] runUntilDate:[NSDate new]];
 
     XCTAssertTrue(blockWasInvoked, @"Should have invoked the block after the run loop.");
 }
@@ -796,9 +796,9 @@ static NSString *TestNotification = @"TestNotification";
 {
     BOOL bVal = YES, *bPtr = &bVal;
     [[[mock stub] ignoringNonObjectArgs] enumerateLinesUsingBlock:[OCMArg invokeBlockAsyncWithArgs:@"First param", OCMOCK_VALUE(bPtr), nil]];
-    __block BOOL blockWasInvoked;
-    __block NSString *firstParam;
-    __block BOOL *secondParam;
+    __block BOOL blockWasInvoked = NO;
+    __block NSString *firstParam = nil;
+    __block BOOL *secondParam = NULL;
 
     [mock enumerateLinesUsingBlock:^(NSString * _Nonnull line, BOOL * _Nonnull stop) {
         blockWasInvoked = YES;
@@ -807,7 +807,7 @@ static NSString *TestNotification = @"TestNotification";
     }];
     XCTAssertFalse(blockWasInvoked, @"Should not have invoked the block before the run loop.");
 
-    [[NSRunLoop mainRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:.01]];
+    [[NSRunLoop mainRunLoop] runUntilDate:[NSDate new]];
 
     XCTAssertTrue(blockWasInvoked, @"Should have invoked the block after the run loop.");
     XCTAssertEqualObjects(firstParam, @"First param", @"First param not passed to the block");


### PR DESCRIPTION
Sometimes it is necessary to call block arg asynchronously in order to mimic the API correctly. This change will allow e.g. usage of `[OCMArg invokeBlockAsync]` as a one-liner for mocking asynchronous calls of completion blocks. There is also asynchronous version of the variant where you can pass arguments to the called block.
