### PR TITLE
Add support for multiple protocol mocks

### DIFF
--- a/Source/OCMock/OCMock.h
+++ b/Source/OCMock/OCMock.h
@@ -31,7 +31,11 @@
 
 #define OCMProtocolMock(protocol) [OCMockObject niceMockForProtocol:protocol]
 
+#define OCMProtocolsMock(protocol, ...) [OCMockObject niceMockForProtocols:protocol, ## __VA_ARGS__]
+
 #define OCMStrictProtocolMock(protocol) [OCMockObject mockForProtocol:protocol]
+
+#define OCMStrictProtocolsMock(protocol, ...) [OCMockObject mockForProtocol:protocol, ## __VA_ARGS__]
 
 #define OCMPartialMock(obj) [OCMockObject partialMockForObject:obj]
 

--- a/Source/OCMock/OCMockObject.h
+++ b/Source/OCMock/OCMockObject.h
@@ -35,10 +35,12 @@
 
 + (id)mockForClass:(Class)aClass;
 + (id)mockForProtocol:(Protocol *)aProtocol;
++ (id)mockForProtocols:(Protocol *)aProtocol, ...;
 + (id)partialMockForObject:(NSObject *)anObject;
 
 + (id)niceMockForClass:(Class)aClass;
 + (id)niceMockForProtocol:(Protocol *)aProtocol;
++ (id)niceMockForProtocols:(Protocol *)aProtocol, ...;
 
 + (id)observerMock;
 

--- a/Source/OCMock/OCMockObject.m
+++ b/Source/OCMock/OCMockObject.m
@@ -54,6 +54,15 @@
 	return [[[OCProtocolMockObject alloc] initWithProtocol:aProtocol] autorelease];
 }
 
++ (id)mockForProtocols:(Protocol *)aProtocol, ...
+{
+    va_list args;
+    va_start(args, aProtocol);
+    id mock = [[[OCProtocolMockObject alloc] initWithProtocols:[self _variadicArgumentsToArray:aProtocol args:args]] autorelease];
+    va_end(args);
+    return mock;
+}
+
 + (id)partialMockForObject:(NSObject *)anObject
 {
 	return [[[OCPartialMockObject alloc] initWithObject:anObject] autorelease];
@@ -68,6 +77,15 @@
 + (id)niceMockForProtocol:(Protocol *)aProtocol
 {
 	return [self _makeNice:[self mockForProtocol:aProtocol]];
+}
+
++ (id)niceMockForProtocols:(Protocol *)aProtocol, ...
+{
+    va_list args;
+    va_start(args, aProtocol);
+    id mock = [self _makeNice:[[[OCProtocolMockObject alloc] initWithProtocols:[self _variadicArgumentsToArray:aProtocol args:args]] autorelease]];
+    va_end(args);
+    return mock;
 }
 
 
@@ -433,5 +451,25 @@
 	return outputString;
 }
 
++ (NSArray *)_variadicArgumentsToArray:(id)firstObject args:(va_list)args
+{
+    NSMutableArray *variadicObjects = nil;
+
+    if(firstObject)
+    {
+        variadicObjects = [[NSMutableArray alloc] init];
+        [variadicObjects addObject:firstObject];
+
+        if(args != nil)
+        {
+            id eachObject;
+            while ((eachObject = va_arg(args, id)) && eachObject != nil) {
+                [variadicObjects addObject:eachObject];
+            }
+        }
+    }
+
+    return [variadicObjects copy];
+}
 
 @end

--- a/Source/OCMock/OCMockObject.m
+++ b/Source/OCMock/OCMockObject.m
@@ -58,7 +58,7 @@
 {
     va_list args;
     va_start(args, aProtocol);
-    id mock = [[[OCProtocolMockObject alloc] initWithProtocols:[self _variadicArgumentsToArray:aProtocol args:args]] autorelease];
+    id mock = [[[OCProtocolMockObject alloc] initWithProtocols:[self _variadicArgumentsToArray:aProtocol args:&args]] autorelease];
     va_end(args);
     return mock;
 }
@@ -83,7 +83,7 @@
 {
     va_list args;
     va_start(args, aProtocol);
-    id mock = [self _makeNice:[[[OCProtocolMockObject alloc] initWithProtocols:[self _variadicArgumentsToArray:aProtocol args:args]] autorelease]];
+    id mock = [self _makeNice:[[[OCProtocolMockObject alloc] initWithProtocols:[self _variadicArgumentsToArray:aProtocol args:&args]] autorelease]];
     va_end(args);
     return mock;
 }
@@ -451,25 +451,25 @@
 	return outputString;
 }
 
-+ (NSArray *)_variadicArgumentsToArray:(id)firstObject args:(va_list)args
++ (NSArray *)_variadicArgumentsToArray:(id)firstObject args:(va_list *)args
 {
     NSMutableArray *variadicObjects = nil;
 
     if(firstObject)
     {
-        variadicObjects = [[NSMutableArray alloc] init];
+        variadicObjects = [[[NSMutableArray alloc] init] autorelease];
         [variadicObjects addObject:firstObject];
 
-        if(args != nil)
+        if(args)
         {
             id eachObject;
-            while ((eachObject = va_arg(args, id)) && eachObject != nil) {
+            while ((eachObject = va_arg(*args, typeof(firstObject)))) {
                 [variadicObjects addObject:eachObject];
             }
         }
     }
 
-    return [variadicObjects copy];
+    return variadicObjects;
 }
 
 @end

--- a/Source/OCMock/OCProtocolMockObject.h
+++ b/Source/OCMock/OCProtocolMockObject.h
@@ -18,10 +18,11 @@
 
 @interface OCProtocolMockObject : OCMockObject 
 {
-	Protocol	*mockedProtocol;
+	NSArray<Protocol *> *mockedProtocols;
 }
 
 - (id)initWithProtocol:(Protocol *)aProtocol;
+- (id)initWithProtocols:(NSArray<Protocol *> *)protocols;
 
 @end
 

--- a/Source/OCMockTests/OCMockObjectProtocolMocksTests.m
+++ b/Source/OCMockTests/OCMockObjectProtocolMocksTests.m
@@ -70,10 +70,28 @@ typedef InterfaceForTypedef* PointerTypedefInterface;
     [mock verify];
 }
 
+- (void)testCanMockMultipleFormalProtocols
+{
+    id mock = [OCMockObject mockForProtocols:@protocol(NSLocking), @protocol(NSObject)];
+    [[mock expect] lock];
+    [[mock expect] isProxy];
+
+    [mock lock];
+    [mock isProxy];
+
+    [mock verify];
+}
+
 - (void)testSetsCorrectNameForProtocolMockObjects
 {
     id mock = [OCMockObject mockForProtocol:@protocol(NSLocking)];
     XCTAssertEqualObjects(@"OCMockObject(NSLocking)", [mock description], @"Should have returned correct description.");
+}
+
+- (void)testSetsCorrectNameForMultiProtocolMockObjects
+{
+    id mock = [OCMockObject mockForProtocols:@protocol(NSLocking), @protocol(NSObject)];
+    XCTAssertEqualObjects(@"OCMockObject(NSLocking, NSObject)", [mock description], @"Should have returned correct description.");
 }
 
 - (void)testRaisesWhenUnknownMethodIsCalledOnProtocol
@@ -86,6 +104,13 @@ typedef InterfaceForTypedef* PointerTypedefInterface;
 {
     id mock = [OCMockObject mockForProtocol:@protocol(NSLocking)];
     XCTAssertTrue([mock conformsToProtocol:@protocol(NSLocking)]);
+}
+
+- (void)testConformsToMockedMultiProtocols
+{
+    id mock = [OCMockObject mockForProtocols:@protocol(NSLocking), @protocol(NSObject)];
+    XCTAssertTrue([mock conformsToProtocol:@protocol(NSLocking)]);
+    XCTAssertTrue([mock conformsToProtocol:@protocol(NSObject)]);
 }
 
 - (void)testRespondsToValidProtocolRequiredSelector
@@ -106,19 +131,22 @@ typedef InterfaceForTypedef* PointerTypedefInterface;
     XCTAssertFalse([mock respondsToSelector:@selector(testDoesNotRespondToInvalidProtocolSelector)]);
 }
 
-- (void)testWithTypedefReturnType {
+- (void)testWithTypedefReturnType
+{
     id mock = [OCMockObject mockForProtocol:@protocol(ProtocolWithTypedefs)];
     XCTAssertNoThrow([[[mock stub] andReturn:[TypedefInterface new]] typedefReturnValue1], @"Should accept a typedefed return-type");
     XCTAssertNoThrow([mock typedefReturnValue1]);
 }
 
-- (void)testWithTypedefPointerReturnType {
+- (void)testWithTypedefPointerReturnType
+{
     id mock = [OCMockObject mockForProtocol:@protocol(ProtocolWithTypedefs)];
     XCTAssertNoThrow([[[mock stub] andReturn:[TypedefInterface new]] typedefReturnValue2], @"Should accept a typedefed return-type");
     XCTAssertNoThrow([mock typedefReturnValue2]);
 }
 
-- (void)testWithTypedefParameter {
+- (void)testWithTypedefParameter
+{
     id mock = [OCMockObject mockForProtocol:@protocol(ProtocolWithTypedefs)];
     XCTAssertNoThrow([[mock stub] typedefParameter:nil], @"Should accept a typedefed parameter-type");
     XCTAssertNoThrow([mock typedefParameter:nil]);
@@ -147,9 +175,22 @@ typedef InterfaceForTypedef* PointerTypedefInterface;
     XCTAssertEqual(@"stubbed", result, @"Should have stubbed the class method.");
 }
 
+- (void)testMultipleProtocolClassMethod
+{
+    id mock = OCMProtocolsMock(@protocol(TestProtocol), @protocol(NSLocking));
+    OCMStub([mock stringValueClassMethod]).andReturn(@"stubbed");
+    id result = [mock stringValueClassMethod];
+    XCTAssertEqual(@"stubbed", result, @"Should have stubbed the class method.");
+}
+
 - (void)testRefusesToCreateProtocolMockForNilProtocol
 {
     XCTAssertThrows(OCMProtocolMock(nil));
+}
+
+- (void)testRefusesToCreateMultipleProtocolMockForNilProtocol
+{
+    XCTAssertThrows(OCMProtocolsMock(nil));
 }
 
 @end

--- a/Source/OCMockTests/OCMockObjectRuntimeTests.m
+++ b/Source/OCMockTests/OCMockObjectRuntimeTests.m
@@ -122,6 +122,9 @@ typedef NSString TypedefString;
 {
     id mock = [OCMockObject niceMockForClass:[NSMutableArray class]];
     id anArray = [[NSMutableArray alloc] init];
+
+    XCTAssertNotNil(mock);
+    XCTAssertNotNil(anArray);
 }
 
 


### PR DESCRIPTION
- Remove warnings in `OCMockObjectRuntimeTests.m`
- Add tests in `OCMockObjectProtocolMocksTests.m` to test new multiple protocol mock
- Add new macros to create multi-`Protocol` mocks with variadic methods

Completes #178.
