### PR TITLE
Ignore rejection expectations during async verification

### DIFF
--- a/Source/OCMock.xcodeproj/xcshareddata/xcbaselines/03565A3018F0566E003AE91E.xcbaseline/AB0B7B4B-6B80-4328-BA16-64F0AC33ED0D.plist
+++ b/Source/OCMock.xcodeproj/xcshareddata/xcbaselines/03565A3018F0566E003AE91E.xcbaseline/AB0B7B4B-6B80-4328-BA16-64F0AC33ED0D.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>classNames</key>
+	<dict>
+		<key>OCMockObjectTests</key>
+		<dict>
+			<key>testAsynchronousVerificationWithRejectionsPerformance</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.0011296</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/Source/OCMock.xcodeproj/xcshareddata/xcbaselines/03565A3018F0566E003AE91E.xcbaseline/Info.plist
+++ b/Source/OCMock.xcodeproj/xcshareddata/xcbaselines/03565A3018F0566E003AE91E.xcbaseline/Info.plist
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>runDestinationsByUUID</key>
+	<dict>
+		<key>AB0B7B4B-6B80-4328-BA16-64F0AC33ED0D</key>
+		<dict>
+			<key>localComputer</key>
+			<dict>
+				<key>busSpeedInMHz</key>
+				<integer>100</integer>
+				<key>cpuCount</key>
+				<integer>1</integer>
+				<key>cpuKind</key>
+				<string>Intel Core i5</string>
+				<key>cpuSpeedInMHz</key>
+				<integer>2900</integer>
+				<key>logicalCPUCoresPerPackage</key>
+				<integer>4</integer>
+				<key>modelCode</key>
+				<string>MacBookPro12,1</string>
+				<key>physicalCPUCoresPerPackage</key>
+				<integer>2</integer>
+				<key>platformIdentifier</key>
+				<string>com.apple.platform.macosx</string>
+			</dict>
+			<key>targetArchitecture</key>
+			<string>x86_64</string>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/Source/OCMock/OCMockObject.m
+++ b/Source/OCMock/OCMockObject.m
@@ -216,7 +216,15 @@
     {
         @synchronized(expectations)
         {
-            if([expectations count] == 0)
+            BOOL hasNonRejectExpectations = NO;
+            for(OCMInvocationExpectation *expectation in expectations) {
+                if(![expectation isMatchAndReject]) {
+                    hasNonRejectExpectations = YES;
+                    break;
+                }
+            }
+
+            if(!hasNonRejectExpectations)
                 break;
         }
         [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:MIN(step, delay)]];

--- a/Source/OCMockTests/OCMockObjectTests.m
+++ b/Source/OCMockTests/OCMockObjectTests.m
@@ -1070,6 +1070,22 @@ static NSString *TestNotification = @"TestNotification";
     XCTAssertEqual(2, count, @"Should have evaluated constraint only twice");
 }
 
+- (void)testAsynchronousVerificationWithRejectionsPerformance
+{
+    mock = [OCMockObject niceMockForClass:[NSString class]];
+
+    [[mock reject] hasSuffix:OCMOCK_ANY];
+    [[mock expect] hasPrefix:OCMOCK_ANY];
+
+    [self measureBlock:^{
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.01 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+            [mock hasPrefix:@"hello"];
+        });
+
+        [mock verifyWithDelay:1];
+    }];
+}
+
 @end
 
 


### PR DESCRIPTION
Without that fix, a test using both async verification & rejections
would wait for the whole given delay.

Performance test to confirm the problem & verify the fix included.

I also included baselines for the mentioned performance test.

I tried to write a regression test to verify that rejections do indeed work (i.e. throw) during async verification, like that:

```
- (void)testRejectsInvocationDuringAsynchronousVerification
{
   OCMockObject *localMock = [OCMockObject niceMockForClass:[TestClassWithProperty class]];

   [[localMock reject] title];
   [[localMock expect] setTitle:OCMOCK_ANY];

   dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.01 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
       [(id) localMock title];
   });

   @try {
       [localMock verifyWithDelay:1];
   } @catch(NSException *exception)  {
       // Expected
   }
}
```
But it seems that exceptions thrown inside the `NSRunLoop` call will crash the app immediately.