### PR TITLE
Implemented strict/nice mock behaviour switching.

### DIFF
--- a/Source/OCMock/OCMock.h
+++ b/Source/OCMock/OCMock.h
@@ -25,11 +25,11 @@
 #import <OCMock/OCMFunctions.h>
 
 
-#define OCMClassMock(cls) [OCMockObject niceMockForClass:cls]
+#define OCMClassMock(cls) ({ id _mock = [OCMockObject mockForClass:cls]; [_mock makeNice]; _mock; })
 
 #define OCMStrictClassMock(cls) [OCMockObject mockForClass:cls]
 
-#define OCMProtocolMock(protocol) [OCMockObject niceMockForProtocol:protocol]
+#define OCMProtocolMock(protocol) ({ id _mock = [OCMockObject mockForProtocol:protocol]; [_mock makeNice]; _mock; })
 
 #define OCMStrictProtocolMock(protocol) [OCMockObject mockForProtocol:protocol]
 

--- a/Source/OCMock/OCMockObject.h
+++ b/Source/OCMock/OCMockObject.h
@@ -37,13 +37,12 @@
 + (id)mockForProtocol:(Protocol *)aProtocol;
 + (id)partialMockForObject:(NSObject *)anObject;
 
-+ (id)niceMockForClass:(Class)aClass;
-+ (id)niceMockForProtocol:(Protocol *)aProtocol;
-
 + (id)observerMock;
 
 - (instancetype)init;
 
+- (void)makeNice;
+- (void)makeStrict;
 - (void)setExpectationOrderMatters:(BOOL)flag;
 
 - (id)stub;

--- a/Source/OCMock/OCMockObject.m
+++ b/Source/OCMock/OCMockObject.m
@@ -59,25 +59,6 @@
 	return [[[OCPartialMockObject alloc] initWithObject:anObject] autorelease];
 }
 
-
-+ (id)niceMockForClass:(Class)aClass
-{
-	return [self _makeNice:[self mockForClass:aClass]];
-}
-
-+ (id)niceMockForProtocol:(Protocol *)aProtocol
-{
-	return [self _makeNice:[self mockForProtocol:aProtocol]];
-}
-
-
-+ (id)_makeNice:(OCMockObject *)mock
-{
-	mock->isNice = YES;
-	return mock;
-}
-
-
 + (id)observerMock
 {
 	return [[[OCObserverMockObject alloc] init] autorelease];
@@ -137,6 +118,16 @@
 
 
 #pragma mark  Public API
+
+- (void)makeNice
+{
+    isNice = YES;
+}
+
+- (void)makeStrict
+{
+    isNice = NO;
+}
 
 - (void)setExpectationOrderMatters:(BOOL)flag
 {

--- a/Source/OCMockTests/OCMockObjectProtocolMocksTests.m
+++ b/Source/OCMockTests/OCMockObjectProtocolMocksTests.m
@@ -127,14 +127,16 @@ typedef InterfaceForTypedef* PointerTypedefInterface;
 
 - (void)testReturnDefaultValueWhenUnknownMethodIsCalledOnNiceProtocolMock
 {
-    id mock = [OCMockObject niceMockForProtocol:@protocol(TestProtocol)];
+    id mock = [OCMockObject mockForProtocol:@protocol(TestProtocol)];
+    [mock makeNice];
     XCTAssertTrue(0 == [mock primitiveValue], @"Should return 0 on unexpected method call (for nice mock).");
     [mock verify];
 }
 
 - (void)testRaisesAnExceptionWenAnExpectedMethodIsNotCalledOnNiceProtocolMock
 {
-    id mock = [OCMockObject niceMockForProtocol:@protocol(TestProtocol)];
+    id mock = [OCMockObject mockForProtocol:@protocol(TestProtocol)];
+    [mock makeNice];
     [[mock expect] primitiveValue];
     XCTAssertThrows([mock verify], @"Should have raised an exception because method was not called.");
 }

--- a/Source/OCMockTests/OCMockObjectRuntimeTests.m
+++ b/Source/OCMockTests/OCMockObjectRuntimeTests.m
@@ -120,7 +120,8 @@ typedef NSString TypedefString;
 
 - (void)testCanMockNSMutableArray
 {
-    id mock = [OCMockObject niceMockForClass:[NSMutableArray class]];
+    id mock = [OCMockObject mockForClass:[NSMutableArray class]];
+    [mock makeNice];
     id anArray = [[NSMutableArray alloc] init];
 }
 

--- a/Source/OCMockTests/OCMockObjectTests.m
+++ b/Source/OCMockTests/OCMockObjectTests.m
@@ -968,21 +968,24 @@ static NSString *TestNotification = @"TestNotification";
 
 - (void)testReturnsDefaultValueWhenUnknownMethodIsCalledOnNiceClassMock
 {
-	mock = [OCMockObject niceMockForClass:[NSString class]];
+	mock = [OCMockObject mockForClass:[NSString class]];
+    [mock makeNice];
 	XCTAssertNil([mock lowercaseString], @"Should return nil on unexpected method call (for nice mock).");
 	[mock verify];
 }
 
 - (void)testRaisesAnExceptionWhenAnExpectedMethodIsNotCalledOnNiceClassMock
 {
-	mock = [OCMockObject niceMockForClass:[NSString class]];
+	mock = [OCMockObject mockForClass:[NSString class]];
+    [mock makeNice];
 	[[[mock expect] andReturn:@"HELLO!"] uppercaseString];
 	XCTAssertThrows([mock verify], @"Should have raised an exception because method was not called.");
 }
 
 - (void)testThrowsWhenRejectedMethodIsCalledOnNiceMock
 {
-    mock = [OCMockObject niceMockForClass:[NSString class]];
+    mock = [OCMockObject mockForClass:[NSString class]];
+    [mock makeNice];
 
     [[mock reject] uppercaseString];
     XCTAssertThrows([mock uppercaseString], @"Should have complained about rejected method being called.");
@@ -990,7 +993,8 @@ static NSString *TestNotification = @"TestNotification";
 
 - (void)testUncalledRejectStubDoesNotCountAsExpectation
 {
-    mock = [OCMockObject niceMockForClass:[NSString class]];
+    mock = [OCMockObject mockForClass:[NSString class]];
+    [mock makeNice];
 
     [[mock expect] lowercaseString];
     [[mock reject] uppercaseString];
@@ -1036,7 +1040,8 @@ static NSString *TestNotification = @"TestNotification";
 
 - (void)testReRaisesRejectExceptionsOnVerify
 {
-	mock = [OCMockObject niceMockForClass:[NSString class]];
+	mock = [OCMockObject mockForClass:[NSString class]];
+    [mock makeNice];
 	[[mock reject] uppercaseString];
 	@try
 	{
@@ -1073,7 +1078,8 @@ static NSString *TestNotification = @"TestNotification";
 
 - (void)testVerifyWithDelayDoesNotWaitForRejects
 {
-    mock = [OCMockObject niceMockForClass:[NSString class]];
+    mock = [OCMockObject mockForClass:[NSString class]];
+    [mock makeNice];
 
     [[mock reject] hasSuffix:OCMOCK_ANY];
     [[mock expect] hasPrefix:OCMOCK_ANY];
@@ -1087,6 +1093,13 @@ static NSString *TestNotification = @"TestNotification";
     NSDate *end = [NSDate date];
     
     XCTAssertTrue([end timeIntervalSinceDate:start] < 3, @"Should have returned before delay was up");
+}
+
+- (void)testRaisesExceptionWhenUnknownMethodIsCalledOnMockReturnedInStrictMode
+{
+    [mock makeNice];
+    [mock makeStrict];
+    XCTAssertThrows([mock uppercaseString], @"Should have raised an exception.");
 }
 
 @end

--- a/Source/OCMockTests/OCMockObjectVerifyAfterRunTests.m
+++ b/Source/OCMockTests/OCMockObjectVerifyAfterRunTests.m
@@ -64,7 +64,8 @@
 
 - (void)testDoesNotThrowWhenMethodWasInvoked
 {
-    id mock = [OCMockObject niceMockForClass:[NSString class]];
+    id mock = [OCMockObject mockForClass:[NSString class]];
+    [mock makeNice];
 
     [mock lowercaseString];
 
@@ -73,7 +74,8 @@
 
 - (void)testThrowsWhenMethodWasNotInvoked
 {
-    id mock = [OCMockObject niceMockForClass:[NSString class]];
+    id mock = [OCMockObject mockForClass:[NSString class]];
+    [mock makeNice];
 
     [mock lowercaseString];
 
@@ -103,7 +105,8 @@
 
 - (void)testDoesNotThrowWhenClassMethodWasInvoked
 {
-    id mock = [OCMockObject niceMockForClass:[TestBaseClassForVerifyAfterRun class]];
+    id mock = [OCMockObject mockForClass:[TestBaseClassForVerifyAfterRun class]];
+    [mock makeNice];
 
     [TestBaseClassForVerifyAfterRun classMethod1];
 
@@ -112,7 +115,8 @@
 
 - (void)testThrowsWhenClassMethodWasNotInvoked
 {
-    id mock = [OCMockObject niceMockForClass:[TestBaseClassForVerifyAfterRun class]];
+    id mock = [OCMockObject mockForClass:[TestBaseClassForVerifyAfterRun class]];
+    [mock makeNice];
 
     XCTAssertThrows([[mock verify] classMethod1], @"Should not have thrown an exception for class method that was called.");
 }


### PR DESCRIPTION
Adds an ability to change mock behaviour from strict mode to nice and vice versa.

**Motivation**
I'd like to use strict mocks as default, this prevents adding new behaviour to classes without adjusting tests (I'm following TDD). However I'd also like to write tests incrementally, i.e. new test for new behaviour. I'd like to focus on single dependency and ignore calls to other dependencies (they're supposed to be covered by corresponding tests). In other words, I'd like to be able to split single complex test case to multiple tests. To do that in current version of OCMock I have to write expectations or stubs for calls I'm not interested in. This leads to a lot of boilerplate and duplicated code.
This small change should make dealing with strict mocks much more easier as well as provides more flexibility for test setup.
