### PR TITLE
[Tests] Ignore unused result warning in test

### DIFF
--- a/Source/OCMockTests/OCMockObjectRuntimeTests.m
+++ b/Source/OCMockTests/OCMockObjectRuntimeTests.m
@@ -184,7 +184,10 @@ typedef NSString TypedefString;
 - (void)testComplainsWhenAttemptIsMadeToStubInitMethodViaMacro
 {
     id mock = [OCMockObject mockForClass:[NSString class]];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-value"
     XCTAssertThrows(OCMStub([mock init]));
+#pragma clang diagnostic pop
 }
 
 


### PR DESCRIPTION
The test asserts that calling `-init` throws -- its result is willfully ignored. Add pragma to instruct the compiler to ignore the warning in this case.