### PR TITLE
[Tests] Ignore unused variable warning in test

### DIFF
--- a/Source/OCMockTests/OCMockObjectRuntimeTests.m
+++ b/Source/OCMockTests/OCMockObjectRuntimeTests.m
@@ -122,6 +122,7 @@ typedef NSString TypedefString;
 {
     id mock = [OCMockObject niceMockForClass:[NSMutableArray class]];
     id anArray = [[NSMutableArray alloc] init];
+#pragma unused(mock, anArray)
 }
 
 


### PR DESCRIPTION
The test verifies that the two lines of code do not crash; the variables are written to but never read. Add pragma to instruct the compiler to ignore the warning in this case.