### PR TITLE
Fixed invokeBlockWithArgs crash when given protocol mocks

### DIFF
--- a/Source/OCMock/NSInvocation+OCMAdditions.m
+++ b/Source/OCMock/NSInvocation+OCMAdditions.m
@@ -118,7 +118,7 @@ static NSString *const OCMRetainedObjectArgumentsKey = @"OCMRetainedObjectArgume
 - (void)setArgumentWithObject:(id)arg atIndex:(NSInteger)idx
 {
 	const char *typeEncoding = [[self methodSignature] getArgumentTypeAtIndex:idx];
-	if((arg == nil) || [arg isKindOfClass:[NSNull class]])
+	if((arg == nil) || ([arg respondsToSelector:@selector(isKindOfClass:)] && [arg isKindOfClass:[NSNull class]]))
 	{
 		if(typeEncoding[0] == '^')
 		{


### PR DESCRIPTION
This aims to resolve https://github.com/erikdoe/ocmock/issues/329.

I have added two new tests for `invokeBlockWithArgs`:
- The test for Protocol mocks crashes without this patch
- The test for Class mocks is for completeness, and does not require this patch