### PR TITLE
Fix "'@interface' command should not be used in a comment attached to a non-interface declaration"

### DIFF
--- a/Source/OCMock/OCClassMockObject.m
+++ b/Source/OCMock/OCClassMockObject.m
@@ -230,7 +230,7 @@
 
 #pragma mark  -
 
-/**
+/*
  taken from:
  `class-dump -f isNS /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator7.0.sdk/System/Library/Frameworks/CoreFoundation.framework`
  


### PR DESCRIPTION
It was generating documentation warning:

> OCClassMockObject.m:237:3: 
> '@interface' command should not be used in a comment attached to a non-interface declaration

![2017-04-21_1758](https://cloud.githubusercontent.com/assets/217368/25300076/719bd57e-26bc-11e7-9f70-dc12235fa60e.png)


