### PR TITLE
Fix comparison of struct type representation.

### DIFF
--- a/Source/OCMock/OCMFunctions.m
+++ b/Source/OCMock/OCMFunctions.m
@@ -118,6 +118,57 @@ CFNumberType OCMNumberTypeForObjCType(const char *objcType)
     }
 }
 
+
+static BOOL ParseStructType(const char *type, const char **typeEnd, const char **typeNameEnd, const char **typeEqualSign)
+{
+  if (type[0] != '{' && type[0] != '(')
+      return NO;
+
+  *typeNameEnd = NULL;
+  *typeEqualSign = NULL;
+
+  const char endChar = type[0] == '{' ? '}' : ')';
+  for (const char* ptr = type + 1; *ptr; ++ptr) {
+      switch (*ptr) {
+          case '(':
+          case '{':
+          {
+              const char *subTypeEnd;
+              const char *subTypeNameEnd;
+              const char *subTypeEqualSign;
+              if (!ParseStructType(ptr, &subTypeEnd, &subTypeNameEnd, &subTypeEqualSign))
+                  return NO;
+              ptr = subTypeEnd;
+              break;
+          }
+          case '=':
+          {
+              if (!*typeEqualSign) {
+                  *typeNameEnd = ptr;
+                  *typeEqualSign = ptr;
+              }
+              break;
+          }
+          case ')':
+          case '}':
+          {
+              if (*ptr == endChar) {
+                  *typeEnd = ptr;
+                  if (!*typeNameEnd)
+                      *typeNameEnd = ptr;
+                  return YES;
+              }
+              break;
+          }
+          default:
+              break;
+      }
+  }
+
+  return NO;
+}
+
+
 /*
  * Sometimes an external type is an opaque struct (which will have an @encode of "{structName}"
  * or "{structName=}") but the actual method return type, or property type, will know the contents
@@ -145,27 +196,32 @@ static BOOL OCMEqualTypesAllowingOpaqueStructsInternal(const char *type1, const 
         {
             if (type2[0] != type1[0])
                 return NO;
-            char endChar = type1[0] == '{'? '}' : ')';
 
-            const char *type1End = strchr(type1, endChar);
-            const char *type2End = strchr(type2, endChar);
-            const char *type1Equals = strchr(type1, '=');
-            const char *type2Equals = strchr(type2, '=');
+            const char *type1End;
+            const char *type1NameEnd;
+            const char *type1EqualSign;
+            if (!ParseStructType(type1, &type1End, &type1NameEnd, &type1EqualSign))
+                return NO;
+
+            const char *type2End;
+            const char *type2NameEnd;
+            const char *type2EqualSign;
+            if (!ParseStructType(type2, &type2End, &type2NameEnd, &type2EqualSign))
+                return NO;
 
             /* Opaque types either don't have an equals sign (just the name and the end brace), or
              * empty content after the equals sign.
              * We want that to compare the same as a type of the same name but with the content.
              */
-            BOOL type1Opaque = (type1Equals == NULL || (type1End < type1Equals) || type1Equals[1] == endChar);
-            BOOL type2Opaque = (type2Equals == NULL || (type2End < type2Equals) || type2Equals[1] == endChar);
-            const char *type1NameEnd = (type1Equals == NULL || (type1End < type1Equals)) ? type1End : type1Equals;
-            const char *type2NameEnd = (type2Equals == NULL || (type2End < type2Equals)) ? type2End : type2Equals;
+            BOOL type1Opaque = (type1EqualSign == NULL || type1EqualSign + 1 == type1End);
+            BOOL type2Opaque = (type2EqualSign == NULL || type2EqualSign + 2 == type2End);
             intptr_t type1NameLen = type1NameEnd - type1;
             intptr_t type2NameLen = type2NameEnd - type2;
 
             /* If the names are not equal and neither of the names is a question mark, return NO */
             if ((type1NameLen != type2NameLen || strncmp(type1, type2, type1NameLen)) &&
-                !((type1NameLen == 2) && (type1[1] == '?')) && !((type2NameLen == 2) && (type2[1] == '?')))
+                !((type1NameLen == 2) && (type1[1] == '?')) && !((type2NameLen == 2) && (type2[1] == '?')) &&
+                !(type1NameLen == 1 || type2NameLen == 1))
                 return NO;
 
             /* If the same name, and at least one is opaque, that is close enough. */
@@ -173,14 +229,32 @@ static BOOL OCMEqualTypesAllowingOpaqueStructsInternal(const char *type1, const 
                 return YES;
 
             /* Otherwise, compare all the elements.  Use NSGetSizeAndAlignment to walk through the struct elements. */
-            type1 = type1Equals + 1;
-            type2 = type2Equals + 1;
-            while (type1[0] != endChar && type1[0] != '\0')
+            type1 = type1EqualSign + 1;
+            type2 = type2EqualSign + 1;
+            while (type1 != type1End && *type1)
             {
                 if (!OCMEqualTypesAllowingOpaqueStructs(type1, type2))
                     return NO;
-                type1 = NSGetSizeAndAlignment(type1, NULL, NULL);
-                type2 = NSGetSizeAndAlignment(type2, NULL, NULL);
+
+                if (*type1 != '{' && *type1 != '(') {
+                    type1 = NSGetSizeAndAlignment(type1, NULL, NULL);
+                    type2 = NSGetSizeAndAlignment(type2, NULL, NULL);
+                } else {
+                    const char *subType1End;
+                    const char *subType1NameEnd;
+                    const char *subType1EqualSign;
+                    if (!ParseStructType(type1, &subType1End, &subType1NameEnd, &subType1EqualSign))
+                        return NO;
+
+                    const char *subType2End;
+                    const char *subType2NameEnd;
+                    const char *subType2EqualSign;
+                    if (!ParseStructType(type2, &subType2End, &subType2NameEnd, &subType2EqualSign))
+                        return NO;
+
+                    type1 = subType1End + 1;
+                    type2 = subType2End + 1;
+                }
             }
             return YES;
         }

--- a/Source/OCMockTests/OCMBoxedReturnValueProviderTests.m
+++ b/Source/OCMockTests/OCMBoxedReturnValueProviderTests.m
@@ -94,6 +94,31 @@
 }
 
 
+- (void)testCorrectEqualityForStructureWithoutName
+{
+    // see https://github.com/erikdoe/ocmock/issues/342
+    const char *type1 = "r^{GURL={basic_string<char, std::__1::char_traits<char"
+        ">, std::__1::allocator<char> >={__compressed_pair<std::__1::basic_stri"
+        "ng<char, std::__1::char_traits<char>, std::__1::allocator<char> >::__r"
+        "ep, std::__1::allocator<char> >={__rep}}}B{Parsed={Component=ii}{Compo"
+        "nent=ii}{Component=ii}{Component=ii}{Component=ii}{Component=ii}{Compo"
+        "nent=ii}{Component=ii}B^{}}{unique_ptr<GURL, std::__1::default_delete<"
+        "GURL> >={__compressed_pair<GURL *, std::__1::default_delete<GURL> >=^{"
+        "}}}}";
+    const char *type2 = "r^{GURL={basic_string<char, std::__1::char_traits<char"
+        ">, std::__1::allocator<char> >={__compressed_pair<std::__1::basic_stri"
+        "ng<char, std::__1::char_traits<char>, std::__1::allocator<char> >::__r"
+        "ep, std::__1::allocator<char> >={__rep=(?={__long=QQ*}{__short=(?=Cc)["
+        "23c]}{__raw=[3Q]})}}}B{Parsed={Component=ii}{Component=ii}{Component=i"
+        "i}{Component=ii}{Component=ii}{Component=ii}{Component=ii}{Component=i"
+        "i}B^{Parsed}}{unique_ptr<GURL, std::__1::default_delete<GURL> >={__com"
+        "pressed_pair<GURL *, std::__1::default_delete<GURL> >=^{GURL}}}}";
+
+    OCMBoxedReturnValueProvider *boxed = [OCMBoxedReturnValueProvider new];
+    XCTAssertTrue([boxed isMethodReturnType:type1 compatibleWithValueType:type2]);
+
+}
+
 @end
 
 


### PR DESCRIPTION
When building with iOS 11 SDK and running on iOS 10 device, the type
representation, some of structure type are incompatible and are not
considered equal even though they are.

This fixes the comparison by:

1.  properly parsing nested subtypes like {Foo={Bar={B}}}
2.  considering that a struct without a name {} is equal to any struct
3.  not use NSGetSizeAndAlignment to parse subtype like {__rep}

Fixes issue #342.