### PR TITLE
Allow compilation with old deployment targets.

### DIFF
--- a/Source/OCMock/NSInvocation+OCMAdditions.m
+++ b/Source/OCMock/NSInvocation+OCMAdditions.m
@@ -15,9 +15,20 @@
  */
 
 #import <objc/runtime.h>
+#import <Availability.h>
+#import <TargetConditionals.h>
 #import "NSInvocation+OCMAdditions.h"
 #import "OCMFunctionsPrivate.h"
 #import "NSMethodSignature+OCMAdditions.h"
+
+
+#if (TARGET_OS_OSX && (!defined(__MAC_10_10) || __MAC_OS_X_VERSION_MIN_REQUIRED < __MAC_10_10)) || \
+    (TARGET_OS_IPHONE && (!defined(__IPHONE_8_0) || __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_8_0))
+static BOOL OCMObjectIsClass(id object) {
+  return class_isMetaClass(object_getClass(object));
+}
+#define object_isClass OCMObjectIsClass
+#endif
 
 
 @implementation NSInvocation(OCMAdditions)


### PR DESCRIPTION
The function object_isClass is only available starting from macOS
10.10 and iOS 8.0 SDKs. To allow targeting older systems (i.e. if
the deployment target is older), add an alternate implementation.

The implementation is based on the one used by the Swift runtime:
https://github.com/apple/swift/pull/11467/commits/0475307c08

Fixes issue #344.