### PR TITLE
Add method to not retain object arguments.

### DIFF
--- a/Source/OCMock/OCMockObject.h
+++ b/Source/OCMock/OCMockObject.h
@@ -27,6 +27,7 @@
 {
 	BOOL			isNice;
 	BOOL			expectationOrderMatters;
+	BOOL			retainObjectArguments;
 	NSMutableArray	*stubs;
 	NSMutableArray	*expectations;
 	NSMutableArray	*exceptions;
@@ -45,6 +46,7 @@
 - (instancetype)init;
 
 - (void)setExpectationOrderMatters:(BOOL)flag;
+- (id)noRetainObjectArgs;
 
 - (id)stub;
 - (id)expect;

--- a/Source/OCMock/OCMockObject.m
+++ b/Source/OCMock/OCMockObject.m
@@ -98,6 +98,7 @@
     
 	// no [super init], we're inheriting from NSProxy
 	expectationOrderMatters = NO;
+	retainObjectArguments = YES;
 	stubs = [[NSMutableArray alloc] init];
 	expectations = [[NSMutableArray alloc] init];
 	exceptions = [[NSMutableArray alloc] init];
@@ -141,6 +142,11 @@
 - (void)setExpectationOrderMatters:(BOOL)flag
 {
     expectationOrderMatters = flag;
+}
+
+- (id)noRetainObjectArgs {
+	retainObjectArguments = NO;
+	return self;
 }
 
 - (void)stopMocking
@@ -326,7 +332,9 @@
         // value could be self. That would produce a retain cycle self->invocations->anInvocation->self.
         // However we need to retain everything on anInvocation that isn't self because we expect them to
         // stick around after this method returns. Use our special method to retain just what's needed.
-        [anInvocation retainObjectArgumentsExcludingObject:self];
+		if (retainObjectArguments) {
+			[anInvocation retainObjectArgumentsExcludingObject:self];
+		}
         [invocations addObject:anInvocation];
     }
 

--- a/Source/OCMockTests/OCMockObjectTests.m
+++ b/Source/OCMockTests/OCMockObjectTests.m
@@ -171,6 +171,21 @@ TestOpaque myOpaque;
 
 @end
 
+@interface TestClassObjectArgMethod : NSObject
+
+- (void)doStuffWithObject:(id)object;
+
+@end
+
+@implementation TestClassObjectArgMethod
+
+- (void)doStuffWithObject:(id)object
+{
+	// stubbed out anyway
+}
+
+@end
+
 static NSString *TestNotification = @"TestNotification";
 
 
@@ -1168,6 +1183,34 @@ static NSString *TestNotification = @"TestNotification";
     NSDate *end = [NSDate date];
     
     XCTAssertTrue([end timeIntervalSinceDate:start] < 3, @"Should have returned before delay was up");
+}
+
+- (void)testRetainObjectArgs
+{
+	mock = OCMClassMock([TestClassObjectArgMethod class]);
+	NSObject *__weak weakObject;
+
+	@autoreleasepool {
+		NSObject *object = [[NSObject alloc] init];
+		weakObject = object;
+		[mock doStuffWithObject:object];
+	}
+
+	XCTAssertNotNil(weakObject, @"Object should have been retained.");
+}
+
+- (void)testNoRetainObjectArgs
+{
+	mock = [OCMClassMock([TestClassObjectArgMethod class]) noRetainObjectArgs];
+	NSObject *__weak weakObject;
+
+	@autoreleasepool {
+		NSObject *object = [[NSObject alloc] init];
+		weakObject = object;
+		[mock doStuffWithObject:object];
+	}
+
+	XCTAssertNil(weakObject, @"Object should not have been retained.");
 }
 
 @end


### PR DESCRIPTION
OCMock 3.4 retains arguments passed to mocks (https://github.com/erikdoe/ocmock/issues/307) so this provides reverse-compatibility for tests that rely on dealloc being called on the object under test, which was fine in OCMock 3.2 and earlier versions.