### PR TITLE
Retain class type arguments in NSInvocation

### DIFF
--- a/Source/OCMock/NSInvocation+OCMAdditions.m
+++ b/Source/OCMock/NSInvocation+OCMAdditions.m
@@ -80,7 +80,7 @@ static NSString *const OCMRetainedObjectArgumentsKey = @"OCMRetainedObjectArgume
     for(NSUInteger index = 2; index < numberOfArguments; index++)
     {
         const char *argumentType = [[self methodSignature] getArgumentTypeAtIndex:index];
-        if(OCMIsObjectType(argumentType) && !OCMIsClassType(argumentType))
+        if(OCMIsObjectType(argumentType))
         {
             id argument;
             [self getArgument:&argument atIndex:index];
@@ -102,7 +102,7 @@ static NSString *const OCMRetainedObjectArgumentsKey = @"OCMRetainedObjectArgume
     }
 
     const char *returnType = [[self methodSignature] methodReturnType];
-    if(OCMIsObjectType(returnType) && !OCMIsClassType(returnType))
+    if(OCMIsObjectType(returnType))
     {
         id returnValue;
         [self getReturnValue:&returnValue];

--- a/Source/OCMock/OCMFunctions.m
+++ b/Source/OCMock/OCMFunctions.m
@@ -48,11 +48,6 @@ static BOOL OCMIsUnqualifiedClassType(const char *unqualifiedObjCType)
     return (strcmp(unqualifiedObjCType, @encode(Class)) == 0);
 }
 
-BOOL OCMIsClassType(const char *objCType)
-{
-    return OCMIsUnqualifiedClassType(OCMTypeWithoutQualifiers(objCType));
-}
-
 
 static BOOL OCMIsUnqualifiedBlockType(const char *unqualifiedObjCType)
 {

--- a/Source/OCMock/OCMFunctionsPrivate.h
+++ b/Source/OCMock/OCMFunctionsPrivate.h
@@ -21,7 +21,6 @@
 @class OCPartialMockObject;
 
 
-BOOL OCMIsClassType(const char *objCType);
 BOOL OCMIsBlockType(const char *objCType);
 BOOL OCMIsObjectType(const char *objCType);
 const char *OCMTypeWithoutQualifiers(const char *objCType);

--- a/Source/OCMockTests/OCMockObjectTests.m
+++ b/Source/OCMockTests/OCMockObjectTests.m
@@ -171,6 +171,21 @@ TestOpaque myOpaque;
 
 @end
 
+@interface TestClassWithClassArgMethod : NSObject
+
+- (void)doStuffWithClass:(Class)aClass;
+
+@end
+
+@implementation TestClassWithClassArgMethod
+
+- (void)doStuffWithClass:(Class)aClass
+{
+    // stubbed out anyway
+}
+
+@end
+
 static NSString *TestNotification = @"TestNotification";
 
 
@@ -985,7 +1000,6 @@ static NSString *TestNotification = @"TestNotification";
 	XCTAssertThrows([mock verifyWithDelay:0.1], @"Should have raised an exception because method was not called.");
 }
 
-
 // --------------------------------------------------------------------------------------
 //	ordered expectations
 // --------------------------------------------------------------------------------------
@@ -1168,6 +1182,16 @@ static NSString *TestNotification = @"TestNotification";
     NSDate *end = [NSDate date];
     
     XCTAssertTrue([end timeIntervalSinceDate:start] < 3, @"Should have returned before delay was up");
+}
+
+- (void)testClassArgsAreRetained
+{
+
+    id mockWithClassMethod = [OCMockObject mockForClass:[TestClassWithClassArgMethod class]];
+    @autoreleasepool {
+        [[mockWithClassMethod stub] doStuffWithClass:[OCMArg any]];
+    }
+    XCTAssertNoThrow([mockWithClassMethod doStuffWithClass:[NSString class]]);
 }
 
 @end


### PR DESCRIPTION
The arguments passed to the recorder for a method-parameter of type `Class` were not retained, which can cause crashes if they are deallocated before they are used for verification.

As `Class` types are treated with as objects in ObjC, we should just retain them in the same way.