### PR TITLE
Prevent initialization in production code from resetting mock state.

### DIFF
--- a/Source/OCMock/OCMockObject.m
+++ b/Source/OCMock/OCMockObject.m
@@ -31,7 +31,9 @@
 #import "OCMExpectationRecorder.h"
 
 
-@implementation OCMockObject
+@implementation OCMockObject {
+	BOOL initialized;
+}
 
 #pragma mark  Class initialisation
 
@@ -95,7 +97,14 @@
         [recorder setMockObject:self];
         return (id)[recorder init];
     }
-    
+
+	// Prevent initialization in production code from resetting mock state.
+	if (initialized) {
+		return self;
+	} else {
+		initialized = YES;
+	}
+
 	// no [super init], we're inheriting from NSProxy
 	expectationOrderMatters = NO;
 	stubs = [[NSMutableArray alloc] init];

--- a/Source/OCMockTests/OCMockObjectTests.m
+++ b/Source/OCMockTests/OCMockObjectTests.m
@@ -171,6 +171,22 @@ TestOpaque myOpaque;
 
 @end
 
+@interface TestClassObjectInitMethod : NSObject
+
+- (NSString *)testClassProperty;
+
+@end
+
+@implementation TestClassObjectInitMethod
+
+- (NSString *)testClassProperty
+{
+	TestClassWithProperty *testClass = [[TestClassWithProperty alloc] init];
+	return testClass.title;
+}
+
+@end
+
 static NSString *TestNotification = @"TestNotification";
 
 
@@ -1168,6 +1184,18 @@ static NSString *TestNotification = @"TestNotification";
     NSDate *end = [NSDate date];
     
     XCTAssertTrue([end timeIntervalSinceDate:start] < 3, @"Should have returned before delay was up");
+}
+
+- (void)testNoResetMockStateOnInit
+{
+	mock = OCMClassMock([TestClassWithProperty class]);
+	OCMStub([mock alloc]).andReturn(mock);
+
+	NSString *title = @"title";
+	OCMStub([mock title]).andReturn(title);
+
+	TestClassObjectInitMethod *object = [[TestClassObjectInitMethod alloc] init];
+	XCTAssertEqualObjects(title, [object testClassProperty]);
 }
 
 @end


### PR DESCRIPTION
A common pattern in our tests is to create a mock that returns itself from alloc/init in production code. Since init is implemented by the mock itself and therefore can't be stubbed, this returns the mock but resets state including stubs and expectations. The fix is to simply prevent resetting mock state when init is called multiple times.