### PR TITLE
When a second mock is created for the same class, dispose of the dynamically created subclass for the first mock.

### DIFF
--- a/Source/OCMock/OCClassMockObject.m
+++ b/Source/OCMock/OCClassMockObject.m
@@ -63,18 +63,13 @@
         const char *createdSubclassName = object_getClassName(mockedClass);
         Class createdSubclass = objc_lookUpClass(createdSubclassName);
 
-        [self restoreMetaClass];
+        OCMSetAssociatedMockForClass(nil, mockedClass);
+        object_setClass(mockedClass, originalMetaClass);
+        originalMetaClass = nil;
 
         objc_disposeClassPair(createdSubclass);
     }
     [super stopMocking];
-}
-
-- (void)restoreMetaClass
-{
-    OCMSetAssociatedMockForClass(nil, mockedClass);
-    object_setClass(mockedClass, originalMetaClass);
-    originalMetaClass = nil;
 }
 
 - (void)addStub:(OCMInvocationStub *)aStub
@@ -96,7 +91,7 @@
     /* if there is another mock for this exact class, stop it */
     id otherMock = OCMGetAssociatedMockForClass(mockedClass, NO);
     if(otherMock != nil)
-        [otherMock restoreMetaClass];
+        [otherMock stopMocking];
 
     OCMSetAssociatedMockForClass(self, mockedClass);
 

--- a/Source/OCMockTests/OCMockObjectClassMethodMockingTests.m
+++ b/Source/OCMockTests/OCMockObjectClassMethodMockingTests.m
@@ -257,6 +257,34 @@ static NSUInteger initializeCallCount = 0;
     XCTAssertNoThrow([TestClassWithClassMethods foo]);
 }
 
+- (void)testStopMockingDisposesMetaClass
+{
+    id mock = [[OCClassMockObject alloc] initWithClass:[TestClassWithClassMethods class]];
+
+    const char *createdSubclassName = object_getClassName([TestClassWithClassMethods class]);
+    XCTAssertNotNil(objc_lookUpClass(createdSubclassName));
+
+    [mock stopMocking];
+    XCTAssertNil(objc_lookUpClass(createdSubclassName));
+}
+
+- (void)testSecondClassMockDisposesFirstMetaClass
+{
+    id mock1 = [[OCClassMockObject alloc] initWithClass:[TestClassWithClassMethods class]];
+    const char *createdSubclassName1 = object_getClassName([TestClassWithClassMethods class]);
+    XCTAssertNotNil(objc_lookUpClass(createdSubclassName1));
+
+    id mock2 = [[OCClassMockObject alloc] initWithClass:[TestClassWithClassMethods class]];
+    const char *createdSubclassName2 = object_getClassName([TestClassWithClassMethods class]);
+    XCTAssertNotNil(objc_lookUpClass(createdSubclassName2));
+
+    [mock1 stopMocking];
+    [mock2 stopMocking];
+
+    XCTAssertNil(objc_lookUpClass(createdSubclassName1));
+    XCTAssertNil(objc_lookUpClass(createdSubclassName2));
+}
+
 - (void)testForwardToRealObject
 {
     NSString *classFooValue = [TestClassWithClassMethods foo];


### PR DESCRIPTION
Previously that first dynamically created subclass was kept around forever,
and if accessed somehow (for example by enumerating objc_getClassList) would
always raise NSInternalInconsistencyException.