### PR TITLE
add replace feature so that we can remock method result

### DIFF
--- a/Source/OCMock/OCMStubRecorder.h
+++ b/Source/OCMock/OCMStubRecorder.h
@@ -27,7 +27,7 @@
 - (id)andCall:(SEL)selector onObject:(id)anObject;
 - (id)andDo:(void (^)(NSInvocation *invocation))block;
 - (id)andForwardToRealObject;
-
+- (id)replace;
 @end
 
 
@@ -57,6 +57,9 @@
 
 #define andForwardToRealObject() _andForwardToRealObject()
 @property (nonatomic, readonly) OCMStubRecorder *(^ _andForwardToRealObject)(void);
+
+#define replace(aBlock) _replace(aBlock)
+@property (nonatomic, readonly) OCMStubRecorder *(^ _replace)(void);
 
 @end
 

--- a/Source/OCMock/OCMStubRecorder.m
+++ b/Source/OCMock/OCMStubRecorder.m
@@ -26,6 +26,9 @@
 #import "OCMFunctions.h"
 #import "OCMInvocationStub.h"
 
+@interface OCMStubRecorder()
+@property (nonatomic, assign) BOOL replaceFlag;
+@end
 
 @implementation OCMStubRecorder
 
@@ -91,13 +94,21 @@
     return self;
 }
 
-
+- (id)replace
+{
+    self.replaceFlag = YES;
+    return self;
+}
 #pragma mark Finishing recording
 
 - (void)forwardInvocation:(NSInvocation *)anInvocation
 {
     [super forwardInvocation:anInvocation];
-    [mockObject addStub:[self stub]];
+    if (self.replaceFlag) {
+        [mockObject replaceStub:[self stub]];
+    } else {
+        [mockObject addStub:[self stub]];
+    }
 }
 
 
@@ -182,6 +193,17 @@
     id (^theBlock)(void) = ^ (void)
     {
         return [self andForwardToRealObject];
+    };
+    return [[theBlock copy] autorelease];
+}
+
+@dynamic _replace;
+
+- (OCMStubRecorder *(^)(void))_replace
+{
+    id (^theBlock)(void) = ^ (void)
+    {
+        return [self replace];
     };
     return [[theBlock copy] autorelease];
 }

--- a/Source/OCMock/OCMockObject.h
+++ b/Source/OCMock/OCMockObject.h
@@ -61,6 +61,7 @@
 // internal use only
 
 - (void)addStub:(OCMInvocationStub *)aStub;
+- (void)replaceStub:(OCMInvocationStub *)aStub;
 - (void)addExpectation:(OCMInvocationExpectation *)anExpectation;
 
 - (BOOL)handleInvocation:(NSInvocation *)anInvocation;

--- a/Source/OCMock/OCMockObject.m
+++ b/Source/OCMock/OCMockObject.m
@@ -127,6 +127,27 @@
     }
 }
 
+- (void)replaceStub:(OCMInvocationStub *)aStub
+{
+    @synchronized(stubs)
+    {
+        __block OCMInvocationStub *removeStub = nil;
+        __block NSUInteger replaceIdx = 0;
+        [stubs enumerateObjectsUsingBlock:^(OCMInvocationStub * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
+            if ([obj matchesInvocation:aStub.recordedInvocation]) {
+                removeStub = obj;
+                replaceIdx = idx;
+                *stop = YES;
+            }
+        }];
+        if (removeStub) {
+            [stubs replaceObjectAtIndex:replaceIdx withObject:aStub];
+        } else {
+            [stubs addObject:aStub];
+        }
+    }
+}
+
 - (void)addExpectation:(OCMInvocationExpectation *)anExpectation
 {
     @synchronized(expectations)


### PR DESCRIPTION
because sometime we need remock some method and return different mock result, and it seems expect feature only affect one by one, but sometimes we don't care or don't known how much times the method is invoked. 

so use replace feature to replace existing mocked method and return a different result maybe a way to solved some special cases.