### PR TITLE
Avoid retaining return value if it is the mock itself

### DIFF
--- a/Source/OCMock/OCMReturnValueProvider.h
+++ b/Source/OCMock/OCMReturnValueProvider.h
@@ -19,9 +19,11 @@
 @interface OCMReturnValueProvider : NSObject 
 {
 	id	returnValue;
+	BOOL valueRetained;
 }
 
 - (instancetype)initWithValue:(id)aValue;
+- (instancetype)initWithValue:(id)aValue shouldRetain:(BOOL)shouldRetain;
 
 - (void)handleInvocation:(NSInvocation *)anInvocation;
 

--- a/Source/OCMock/OCMReturnValueProvider.m
+++ b/Source/OCMock/OCMReturnValueProvider.m
@@ -26,15 +26,38 @@
     if ((self = [super init]))
     {
         returnValue = [aValue retain];
+        valueRetained = YES;
     }
+	
+	return self;
+}
+
+- (instancetype)initWithValue:(id)aValue shouldRetain:(BOOL)shouldRetain
+{
+	if ((self = [super init]))
+	{
+		if (shouldRetain)
+		{
+			returnValue = [aValue retain];
+			valueRetained = YES;
+		}
+		else
+		{
+			returnValue = aValue;
+			valueRetained = NO;
+		}
+	}
 	
 	return self;
 }
 
 - (void)dealloc
 {
-	[returnValue release];
-	[super dealloc];
+    if (valueRetained)
+    {
+        [returnValue release];
+    }
+    [super dealloc];
 }
 
 - (void)handleInvocation:(NSInvocation *)anInvocation

--- a/Source/OCMock/OCMStubRecorder.m
+++ b/Source/OCMock/OCMStubRecorder.m
@@ -61,6 +61,12 @@
 	return self;
 }
 
+- (id)andReturnSameMock:(id)anObject
+{
+	[[self stub] addInvocationAction:[[[OCMReturnValueProvider alloc] initWithValue:anObject shouldRetain:NO] autorelease]];
+	return self;
+}
+
 - (id)andThrow:(NSException *)anException
 {
     [[self stub] addInvocationAction:[[[OCMExceptionReturnValueProvider alloc] initWithValue:anException] autorelease]];
@@ -116,6 +122,10 @@
         {
             NSValue *objValue = nil;
             [aValue getValue:&objValue];
+            if ((id)objValue == mockObject)
+            {
+                return [self andReturnSameMock:objValue];
+            }
             return [self andReturn:objValue];
         }
         else

--- a/Source/OCMockTests/OCMockObjectTests.m
+++ b/Source/OCMockTests/OCMockObjectTests.m
@@ -199,6 +199,29 @@ static NSString *TestNotification = @"TestNotification";
 @end
 
 
+@interface TestClassWithClassMethod : NSObject
+
++ (id)shared;
+- (NSString *)doStuffWithClass;
+
+@end
+
+
+@implementation TestClassWithClassMethod
+
++ (id)shared
+{
+	return [TestClassWithClassMethod new];
+}
+
+- (NSString *)doStuffWithClass;
+{
+	return @"Original value";
+}
+
+@end
+
+
 // --------------------------------------------------------------------------------------
 //  setup
 // --------------------------------------------------------------------------------------
@@ -572,6 +595,21 @@ static NSString *TestNotification = @"TestNotification";
     [[[(id)myMock stub] andReturn:@"stubbed title"] title];
 
     XCTAssertEqualObjects(@"stubbed title", myMock.title);
+}
+
+- (void)testStabReturnsSameMockWithoutRetainCycle
+{
+    @autoreleasepool {
+        id mockWithClassMethod = OCMClassMock([TestClassWithClassMethod class]);
+        OCMStub([mockWithClassMethod doStuffWithClass]).andReturn(@"Stubbed value");
+        OCMStub([mockWithClassMethod shared]).andReturn(mockWithClassMethod);
+        id mockSingletone = [TestClassWithClassMethod shared];
+        
+        XCTAssertEqualObjects(@"Stubbed value", [mockSingletone doStuffWithClass], @"Should return stubbed value");
+    }
+    id singletone = [TestClassWithClassMethod shared];
+    
+    XCTAssertEqualObjects(@"Original value", [singletone doStuffWithClass], @"Should return original value");
 }
 
 


### PR DESCRIPTION
Fixing issue: https://github.com/erikdoe/ocmock/issues/356
In current commit there are: example of the #365 issue and its solution.

When returned object is the same as the mocked object for stub - do not invoke retain.
Mocked-object's lifetime is always longer than stub-object’s, therefore we do not worry that stub-object will be freed earlier than mocked-object(aka returned object).

Co-Authored-By: QB <victoriaqb@users.noreply.github.com>