### PR TITLE
Avoid a macros misuse

### DIFF
--- a/Source/OCMock/OCMMacroState.m
+++ b/Source/OCMock/OCMMacroState.m
@@ -42,6 +42,11 @@ static NSString *const OCMGlobalStateKey = @"OCMGlobalStateKey";
     OCMMacroState *globalState = threadDictionary[OCMGlobalStateKey];
     OCMStubRecorder *recorder = [(OCMStubRecorder *)[globalState recorder] retain];
     [threadDictionary removeObjectForKey:OCMGlobalStateKey];
+	if (!recorder.isEverInvoked)
+	{
+		[NSException raise:NSInternalInconsistencyException
+					format:@"OCMStub/OCMReject/OCMExpect must be used only to mocked object."];
+	}
     return [recorder autorelease];
 }
 
@@ -86,7 +91,15 @@ static NSString *const OCMGlobalStateKey = @"OCMGlobalStateKey";
 
 + (void)endVerifyMacro
 {
-    [[NSThread currentThread].threadDictionary removeObjectForKey:OCMGlobalStateKey];
+	NSMutableDictionary *threadDictionary = [NSThread currentThread].threadDictionary;
+	OCMMacroState *globalState = threadDictionary[OCMGlobalStateKey];
+	OCMVerifier *verifier = [(OCMVerifier *)[globalState recorder] retain];
+	[threadDictionary removeObjectForKey:OCMGlobalStateKey];
+	if (!verifier.isEverInvoked)
+	{
+		[NSException raise:NSInternalInconsistencyException
+					format:@"OCMVerify must be used only to mocked object."];
+	}
 }
 
 

--- a/Source/OCMock/OCMObserverRecorder.m
+++ b/Source/OCMock/OCMObserverRecorder.m
@@ -18,6 +18,8 @@
 #import <OCMock/OCMConstraint.h>
 #import "NSInvocation+OCMAdditions.h"
 #import "OCMObserverRecorder.h"
+#import "OCMMacroState.h"
+#import "OCMStubRecorder.h"
 
 @interface NSObject(HCMatcherDummy)
 - (BOOL)matches:(id)item;
@@ -41,12 +43,20 @@
 
 - (NSNotification *)notificationWithName:(NSString *)name object:(id)sender
 {
+	OCMMacroState *globalState = [OCMMacroState globalState];
+	OCMStubRecorder *recorder = [(OCMStubRecorder *)[globalState recorder] retain];
+	recorder.isEverInvoked = YES;
+	
 	recordedNotification = [[NSNotification notificationWithName:name object:sender] retain];
 	return nil;
 }
 
 - (NSNotification *)notificationWithName:(NSString *)name object:(id)sender userInfo:(NSDictionary *)userInfo
 {
+	OCMMacroState *globalState = [OCMMacroState globalState];
+	OCMStubRecorder *recorder = [(OCMStubRecorder *)[globalState recorder] retain];
+	recorder.isEverInvoked = YES;
+	
 	recordedNotification = [[NSNotification notificationWithName:name object:sender userInfo:userInfo] retain];
 	return nil;
 }

--- a/Source/OCMock/OCMRecorder.h
+++ b/Source/OCMock/OCMRecorder.h
@@ -26,6 +26,8 @@
     OCMInvocationMatcher *invocationMatcher;
 }
 
+@property(nonatomic, assign) BOOL isEverInvoked;
+
 - (instancetype)init;
 - (instancetype)initWithMockObject:(OCMockObject *)aMockObject;
 

--- a/Source/OCMock/OCMRecorder.m
+++ b/Source/OCMock/OCMRecorder.m
@@ -97,11 +97,13 @@
 - (void)forwardInvocation:(NSInvocation *)anInvocation
 {
 	[anInvocation setTarget:nil];
+	self.isEverInvoked = YES;
     [invocationMatcher setInvocation:anInvocation];
 }
 
 - (void)doesNotRecognizeSelector:(SEL)aSelector
 {
+	self.isEverInvoked = YES;
     [NSException raise:NSInvalidArgumentException format:@"%@: cannot stub/expect/verify method '%@' because no such method exists in the mocked class.", mockObject, NSStringFromSelector(aSelector)];
 }
 

--- a/Source/OCMockTests/OCMockObjectMacroTests.m
+++ b/Source/OCMockTests/OCMockObjectMacroTests.m
@@ -332,6 +332,47 @@
                     @"should throw NSInvalidArgumentException exception");
 }
 
+- (void)testShouldThrowExceptionWhenTryingToVerifyRealObject
+{
+	id realObject = [NSArray array];
+	
+	XCTAssertThrowsSpecificNamed(OCMVerify([realObject addObject:@"foo"]),
+								 NSException,
+								 NSInternalInconsistencyException,
+								 @"should throw NSInternalInconsistencyException exception");
+	
+	id mockObject = OCMClassMock([NSString class]);
+	[mockObject lowercaseString];
+	XCTAssertNoThrow(OCMVerify([mockObject lowercaseString]));
+}
+
+- (void)testShouldThrowExceptionWhenTryingToStubRealObject
+{
+	id realObject = [NSArray array];
+	
+	XCTAssertThrowsSpecificNamed(OCMStub([realObject addObject:@"foo"]),
+								 NSException,
+								 NSInternalInconsistencyException,
+								 @"should throw NSInternalInconsistencyException exception");
+	
+	id mockObject = OCMClassMock([NSString class]);
+	[mockObject lowercaseString];
+	XCTAssertNoThrow(OCMStub([mockObject lowercaseString]));
+}
+
+- (void)testShouldThrowExceptionWhenTryingToRejectRealObject
+{
+	id realObject = [NSArray array];
+	
+	XCTAssertThrowsSpecificNamed(OCMReject([realObject addObject:@"foo"]),
+								 NSException,
+								 NSInternalInconsistencyException,
+								 @"should throw NSInternalInconsistencyException exception");
+	
+	id mockObject = OCMClassMock([NSString class]);
+	[mockObject lowercaseString];
+	XCTAssertNoThrow(OCMReject([mockObject lowercaseString]));
+}
 
 - (void)testCanExplicitlySelectClassMethodForStubs
 {


### PR DESCRIPTION
## **Description of Changes**
Exception raises when OCMStub/OCMReject/OCMExpect used only to mocked object, so we added a flag isEverInvoked to check if the mock exists instead the using a real object. 
If YES - the needed chain of the mocking process raises, if NO - exception “OCMStub/OCMReject/OCMExpect must be used only to mocked object.” Raises to make you understand what goes wrong.

## Motivation and Context
When you uses OCMStub/OCMReject/OCMExpect  on a real object in a test - your test doesn’t check anything and is always green. You must use mocks in the test (class / partial). In this case, the correct code check is performed.

## How Has This Been Tested?
Local and CI successful builds and xctests over the new code.

## Notes
OCMStub/OCMReject/OCMExpect must be used only to mocked object.

Co-Authored-By: QB victoriaqb@users.noreply.github.com