### PR TITLE
Add valid archs for simulator to OCMocklib to silent xcodebuild warnings

### DIFF
--- a/Source/OCMock.xcodeproj/project.pbxproj
+++ b/Source/OCMock.xcodeproj/project.pbxproj
@@ -1559,7 +1559,8 @@
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				VALID_ARCHS = "arm64 armv7 armv7s x86_64 i386";
+				VALID_ARCHS = "arm64 armv7 armv7s arm64e";
+				"VALID_ARCHS[sdk=iphonesimulator*]" = "x86_64 i386";
 			};
 			name = Debug;
 		};
@@ -1577,7 +1578,8 @@
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
-				VALID_ARCHS = "arm64 armv7 armv7s x86_64 i386";
+				VALID_ARCHS = "arm64 armv7 armv7s arm64e";
+				"VALID_ARCHS[sdk=iphonesimulator*]" = "x86_64 i386";
 			};
 			name = Release;
 		};


### PR DESCRIPTION
This fixes command line warnings when running xcodebuild
```
    The iOS Simulator deployment target is set to 5.0, but the range of supported deployment target versions for this platform is 8.0 to 12.2.99. (in target 'OCMockLib')
    Mapping architecture arm64 to x86_64. Ensure that this target's Architectures and Valid Architectures build settings are configured correctly for the iOS Simulator platform. (in target 'OCMockLib')
    Mapping architecture armv7 to i386. Ensure that this target's Architectures and Valid Architectures build settings are configured correctly for the iOS Simulator platform. (in target 'OCMockLib')
    Mapping architecture armv7s to i386. Ensure that this target's Architectures and Valid Architectures build settings are configured correctly for the iOS Simulator platform. (in target 'OCMockLib')
```