### PR TITLE
Silence strict selector matching warning

### DIFF
--- a/Source/OCMock/OCMock.h
+++ b/Source/OCMock/OCMock.h
@@ -108,6 +108,7 @@
     _Pragma("clang diagnostic push") \
     _Pragma("clang diagnostic ignored \"-Wunused-value\"") \
     _Pragma("clang diagnostic ignored \"-Wunused-getter-return-value\"") \
+    _Pragma("clang diagnostic ignored \"-Wstrict-selector-match\"") \
     macro \
     _Pragma("clang diagnostic pop") \
 })


### PR DESCRIPTION
If you enable `-wstrict-selector-matching` in your unit tests you'll get
many errors with OCMock mock objects since they will be of type `id` and
any selector that is referenced must be unique across all types in order
to avoid this error.

Given this is a pretty fundamental aspect of how mocks and OCMock work,
I believe silencing errors here is the right strategy vs disabling this
warning entirely for unit test code.