### PR TITLE
Show description when throwing exceptions because of no invocations

### DIFF
--- a/Source/OCMock/OCMockObject.m
+++ b/Source/OCMock/OCMockObject.m
@@ -144,7 +144,7 @@
 - (void)assertInvocationsArrayIsPresent
 {
     if(invocations == nil) {
-        [NSException raise:NSInternalInconsistencyException format:@"** Cannot handle or verify invocations. This error usually occurs when a mock object is used after stopMocking has been called on it. In most cases it is not necessary to call stopMocking. If you know you have to, please make sure that the mock object is not used afterwards."];
+        [NSException raise:NSInternalInconsistencyException format:@"** Cannot handle or verify invocations on %@. This error usually occurs when a mock object is used after stopMocking has been called on it. In most cases it is not necessary to call stopMocking. If you know you have to, please make sure that the mock object is not used afterwards.", [self description]];
     }
 }
 

--- a/Source/OCMock/OCMockObject.m
+++ b/Source/OCMock/OCMockObject.m
@@ -144,7 +144,7 @@
 - (void)assertInvocationsArrayIsPresent
 {
     if(invocations == nil) {
-        [NSException raise:NSInternalInconsistencyException format:@"** Cannot handle or verify invocations on %@. This error usually occurs when a mock object is used after stopMocking has been called on it. In most cases it is not necessary to call stopMocking. If you know you have to, please make sure that the mock object is not used afterwards.", [self description]];
+        [NSException raise:NSInternalInconsistencyException format:@"** Cannot handle or verify invocations on %@ at %p. This error usually occurs when a mock object is used after stopMocking has been called on it. In most cases it is not necessary to call stopMocking. If you know you have to, please make sure that the mock object is not used afterwards.", [self description], self];
     }
 }
 

--- a/Source/OCMockTests/OCMockObjectInternalTests.m
+++ b/Source/OCMockTests/OCMockObjectInternalTests.m
@@ -202,9 +202,16 @@
     [mock title];
     [mock stopMocking];
 
-    XCTAssertThrowsSpecificNamed([[mock verify] title], NSException, NSInternalInconsistencyException,
-                @"Should not have thrown a NSInternalInconsistencyException when attempting to verify after stopMocking.");
-
+    BOOL threw = NO;
+    @try {
+      [[mock verify] title];
+    } @catch (NSException *ex) {
+        threw = YES;
+        XCTAssertEqualObjects(ex.name, NSInternalInconsistencyException);
+        NSString *expectedReason = [NSString stringWithFormat:@"** Cannot handle or verify invocations on %@ at %p. This error usually occurs when a mock object is used after stopMocking has been called on it. In most cases it is not necessary to call stopMocking. If you know you have to, please make sure that the mock object is not used afterwards.", [mock description], mock];
+        XCTAssertEqualObjects(ex.reason, expectedReason);
+    }
+    XCTAssertTrue(threw, @"Should have thrown a NSInternalInconsistencyException when attempting to verify after stopMocking.");
 }
 
 - (void)testRaisesWhenAttemptingToUseAfterStopMocking
@@ -213,9 +220,17 @@
 
     [mock stopMocking];
 
-    XCTAssertThrowsSpecificNamed([mock title], NSException, NSInternalInconsistencyException,
-                @"Should not have thrown a NSInternalInconsistencyException when attempting to verify after stopMocking.");
-
+    BOOL threw = NO;
+    @try {
+      [[mock verify] title];
+        // [[NSProcessInfo processInfo] arguments];
+    } @catch (NSException *ex) {
+        threw = YES;
+        XCTAssertEqualObjects(ex.name, NSInternalInconsistencyException);
+        NSString *expectedReason = [NSString stringWithFormat:@"** Cannot handle or verify invocations on %@ at %p. This error usually occurs when a mock object is used after stopMocking has been called on it. In most cases it is not necessary to call stopMocking. If you know you have to, please make sure that the mock object is not used afterwards.", [mock description], mock];
+        XCTAssertEqualObjects(ex.reason, expectedReason);
+    }
+    XCTAssertTrue(threw, @"Should have thrown a NSInternalInconsistencyException when attempting to verify after stopMocking.");
 }
 
 

--- a/Source/OCMockTests/OCMockObjectInternalTests.m
+++ b/Source/OCMockTests/OCMockObjectInternalTests.m
@@ -223,7 +223,6 @@
     BOOL threw = NO;
     @try {
       [[mock verify] title];
-        // [[NSProcessInfo processInfo] arguments];
     } @catch (NSException *ex) {
         threw = YES;
         XCTAssertEqualObjects(ex.name, NSInternalInconsistencyException);

--- a/Source/OCMockTests/OCMockObjectVerifyAfterRunTests.m
+++ b/Source/OCMockTests/OCMockObjectVerifyAfterRunTests.m
@@ -124,8 +124,16 @@
     [TestBaseClassForVerifyAfterRun classMethod1];
     [mock stopMocking];
 
-    XCTAssertThrowsSpecificNamed([[mock verify] classMethod1], NSException, NSInternalInconsistencyException,
-                @"Should not have thrown a NSInternalInconsistencyException when attempting to verify after stopMocking.");
+    BOOL threw = NO;
+    @try {
+      [[mock verify] classMethod1];
+    } @catch (NSException *ex) {
+        threw = YES;
+        XCTAssertEqualObjects(ex.name, NSInternalInconsistencyException);
+        NSString *expectedReason = [NSString stringWithFormat:@"** Cannot handle or verify invocations on %@ at %p. This error usually occurs when a mock object is used after stopMocking has been called on it. In most cases it is not necessary to call stopMocking. If you know you have to, please make sure that the mock object is not used afterwards.", [mock description], mock];
+        XCTAssertEqualObjects(ex.reason, expectedReason);
+    }
+    XCTAssertTrue(threw, @"Should have thrown a NSInternalInconsistencyException when attempting to verify after stopMocking.");
 }
 
 


### PR DESCRIPTION
This resolves #380 
Before:
```
*** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: '** Cannot handle or verify invocations. This error usually occurs when a mock object is used after stopMocking has been called on it. In most cases it is not necessary to call stopMocking. If you know you have to, please make sure that the mock object is not used afterwards.'
```
After:
```
*** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: '** Cannot handle or verify invocations on OCMockObject(CLLocationManager). This error usually occurs when a mock object is used after stopMocking has been called on it. In most cases it is not necessary to call stopMocking. If you know you have to, please make sure that the mock object is not used afterwards.'
```