### PR TITLE
Remove #define HC_SHORTHAND since it's dead

### DIFF
--- a/Source/OCMock/OCMockObject.m
+++ b/Source/OCMock/OCMockObject.m
@@ -144,7 +144,7 @@
 - (void)assertInvocationsArrayIsPresent
 {
     if(invocations == nil) {
-        [NSException raise:NSInternalInconsistencyException format:@"** Cannot handle or verify invocations. This error usually occurs when a mock object is used after stopMocking has been called on it. In most cases it is not necessary to call stopMocking. If you know you have to, please make sure that the mock object is not used afterwards."];
+        [NSException raise:NSInternalInconsistencyException format:@"** Cannot handle or verify invocations on %@. This error usually occurs when a mock object is used after stopMocking has been called on it. In most cases it is not necessary to call stopMocking. If you know you have to, please make sure that the mock object is not used afterwards.", [self description]];
     }
 }
 

--- a/Source/OCMockTests/OCMockObjectHamcrestTests.m
+++ b/Source/OCMockTests/OCMockObjectHamcrestTests.m
@@ -15,10 +15,8 @@
  */
 
 #import <XCTest/XCTest.h>
-#import <OCMock/OCMock.h>
-
-#define HC_SHORTHAND
 #import <OCHamcrest/OCHamcrest.h>
+#import <OCMock/OCMock.h>
 
 
 @interface OCMockObjectHamcrestTests : XCTestCase


### PR DESCRIPTION
The `HC_SHORTHAND` macros was removed in `OCHamcrest` long time ago.

See https://github.com/hamcrest/OCHamcrest/commit/f04cdb255f3d9d2d2ca4f8ad10b149753ea4fc76
This macro has been removed and replaced with an inverted macro: HC_DISABLE_SHORT_SYNTAX.
