### PR TITLE
Cast mock arguments in OCMVerify* macros

### DIFF
--- a/Source/OCMock/OCMock.h
+++ b/Source/OCMock/OCMock.h
@@ -101,9 +101,9 @@
 #endif
 
 
-#define OCMVerifyAll(mock) [mock verifyAtLocation:OCMMakeLocation(self, __FILE__, __LINE__)]
+#define OCMVerifyAll(mock) [(OCMockObject *)mock verifyAtLocation:OCMMakeLocation(self, __FILE__, __LINE__)]
 
-#define OCMVerifyAllWithDelay(mock, delay) [mock verifyWithDelay:delay atLocation:OCMMakeLocation(self, __FILE__, __LINE__)]
+#define OCMVerifyAllWithDelay(mock, delay) [(OCMockObject *)mock verifyWithDelay:delay atLocation:OCMMakeLocation(self, __FILE__, __LINE__)]
 
 #define _OCMVerify(invocation) \
 ({ \


### PR DESCRIPTION
In cases where people are doing things like

NSBundle *foo = OCClassMock([NSBundle class])

or

id<MyProtocol> bar = OCClassMock([MyClass class])

calling OCMVerifyAll or OCMVerifyAllWithDelay requires a cast to (OCMockObject *) so that the verify methods can be found. This makes it so callers don't have to constantly do OCMVerifyAll((id)bar) or something similar.