### PR TITLE
Fixes OCMockObjects when init* methods are stubbed under ARC.

### DIFF
--- a/Source/OCMock/OCMExpectationRecorder.m
+++ b/Source/OCMock/OCMExpectationRecorder.m
@@ -39,6 +39,7 @@
 
 - (id)never
 {
+    [self setInitTarget:self];
     [[self expectation] setMatchAndReject:YES];
     return self;
 }

--- a/Source/OCMock/OCMFunctions.m
+++ b/Source/OCMock/OCMFunctions.m
@@ -406,3 +406,63 @@ void OCMReportFailure(OCMLocation *loc, NSString *description)
     }
 
 }
+
+#pragma mark  Functions related to matching method families
+
+static BOOL InvocationMatchesMethodFamilyRestrictions(NSInvocation *invocation, NSString *family)
+{
+    // Definitions here: https://clang.llvm.org/docs/AutomaticReferenceCounting.html#method-families
+
+    // Check to make sure it returns an object.
+    NSMethodSignature *signature = [invocation methodSignature];
+    if (strcmp(signature.methodReturnType, "@") != 0)
+    {
+        return NO;
+    }
+
+    // Check to make sure the selector name matches correctly.
+    NSString *selString = NSStringFromSelector([invocation selector]);
+
+	// First remove underscores (if any).
+	NSRange underScoreRange = [selString rangeOfString:@"^_*" options:NSRegularExpressionSearch];
+	selString = [selString stringByReplacingCharactersInRange:underScoreRange withString:@""];
+	// Then check for prefix.
+    if ([selString hasPrefix:family])
+    {
+        NSUInteger familyLength = [family length];
+        if ([selString length] == familyLength)
+        {
+            // Exact match.
+            return YES;
+        }
+        // Check to make sure next character is not lower case.
+        unichar nextChar = [selString characterAtIndex:familyLength];
+        return !islower(nextChar);
+    }
+    return NO;
+}
+
+BOOL OCMIsInvocationInitFamily(NSInvocation *invocation)
+{
+    return InvocationMatchesMethodFamilyRestrictions(invocation, @"init");
+}
+
+BOOL OCMIsInvocationAllocFamily(NSInvocation *invocation)
+{
+    return InvocationMatchesMethodFamilyRestrictions(invocation, @"alloc");
+}
+
+BOOL OCMIsInvocationCopyFamily(NSInvocation *invocation)
+{
+    return InvocationMatchesMethodFamilyRestrictions(invocation, @"copy");
+}
+
+BOOL OCMIsInvocationMutableCopyFamily(NSInvocation *invocation)
+{
+    return InvocationMatchesMethodFamilyRestrictions(invocation, @"mutableCopy");
+}
+
+BOOL OCMIsInvocationNewFamily(NSInvocation *invocation)
+{
+    return InvocationMatchesMethodFamilyRestrictions(invocation, @"new");
+}

--- a/Source/OCMock/OCMFunctionsPrivate.h
+++ b/Source/OCMock/OCMFunctionsPrivate.h
@@ -40,3 +40,9 @@ void OCMSetAssociatedMockForObject(OCClassMockObject *mock, id anObject);
 OCPartialMockObject *OCMGetAssociatedMockForObject(id anObject);
 
 void OCMReportFailure(OCMLocation *loc, NSString *description);
+
+BOOL OCMIsInvocationInitFamily(NSInvocation *invocation);
+BOOL OCMIsInvocationAllocFamily(NSInvocation *invocation);
+BOOL OCMIsInvocationCopyFamily(NSInvocation *invocation);
+BOOL OCMIsInvocationMutableCopyFamily(NSInvocation *invocation);
+BOOL OCMIsInvocationNewFamily(NSInvocation *invocation);

--- a/Source/OCMock/OCMInvocationStub.m
+++ b/Source/OCMock/OCMInvocationStub.m
@@ -68,7 +68,24 @@
         [recordedArg handleArgument:passedArg];
     }
 
+    BOOL isInit = OCMIsInvocationInitFamily(anInvocation);
+    const id badReturnValue = (id)-1;
+    if (isInit)
+    {
+        id returnVal = badReturnValue;
+        [anInvocation setReturnValue:&returnVal];
+    }
     [invocationActions makeObjectsPerformSelector:@selector(handleInvocation:) withObject:anInvocation];
+    if (isInit) 
+    {
+        id returnVal;
+        [anInvocation getReturnValue:&returnVal];
+        if (returnVal == badReturnValue) 
+        {
+            // Init Family Methods must return something.
+            [NSException raise:NSInvalidArgumentException format:@"%@ was stubbed but no return value set. A return value is required for an init method. If you intended to return nil, make this explicit with .andReturn(nil)", NSStringFromSelector([anInvocation selector])];
+        }
+    }
 }
 
 @end

--- a/Source/OCMock/OCMMacroState.m
+++ b/Source/OCMock/OCMMacroState.m
@@ -71,7 +71,6 @@ static NSString *const OCMGlobalStateKey = @"OCMGlobalStateKey";
 + (void)beginRejectMacro
 {
     OCMExpectationRecorder *recorder = [[[OCMExpectationRecorder alloc] init] autorelease];
-    [recorder never];
     OCMMacroState *macroState = [[OCMMacroState alloc] initWithRecorder:recorder];
     [NSThread currentThread].threadDictionary[OCMGlobalStateKey] = macroState;
     [macroState release];
@@ -79,6 +78,11 @@ static NSString *const OCMGlobalStateKey = @"OCMGlobalStateKey";
 
 + (OCMStubRecorder *)endRejectMacro
 {
+    NSMutableDictionary *threadDictionary = [NSThread currentThread].threadDictionary;
+    // `never` must be called after the invocation has been invoked to avoid running
+    // afoul of ARC's expectations on return values from inits.
+    OCMMacroState *globalState = threadDictionary[OCMGlobalStateKey];
+    [(OCMExpectationRecorder *)[globalState recorder] never];
     return [self endStubMacro];
 }
 

--- a/Source/OCMock/OCMRecorder.h
+++ b/Source/OCMock/OCMRecorder.h
@@ -25,7 +25,9 @@
     OCMockObject         *mockObject;
     OCMInvocationMatcher *invocationMatcher;
     BOOL                 wasUsed;
+    id                   initTarget;
 }
+
 
 - (instancetype)init;
 - (instancetype)initWithMockObject:(OCMockObject *)aMockObject;
@@ -37,6 +39,10 @@
 
 - (id)classMethod;
 - (id)ignoringNonObjectArgs;
+
+// initTarget is the target of the invocation used for making sure init calls return the right value.
+- (id)initTarget;
+- (void)setInitTarget:(id)target;
 
 @end
 

--- a/Source/OCMock/OCMStubRecorder.m
+++ b/Source/OCMock/OCMStubRecorder.m
@@ -51,6 +51,7 @@
 
 - (id)andReturn:(id)anObject
 {
+    [self setInitTarget:self];
     id action;
     if(anObject == mockObject)
     {
@@ -66,36 +67,42 @@
 
 - (id)andReturnValue:(NSValue *)aValue
 {
+    [self setInitTarget:self];
     [[self stub] addInvocationAction:[[[OCMBoxedReturnValueProvider alloc] initWithValue:aValue] autorelease]];
     return self;
 }
 
 - (id)andThrow:(NSException *)anException
 {
+    [self setInitTarget:self];
     [[self stub] addInvocationAction:[[[OCMExceptionReturnValueProvider alloc] initWithValue:anException] autorelease]];
     return self;
 }
 
 - (id)andPost:(NSNotification *)aNotification
 {
+    [self setInitTarget:self];
     [[self stub] addInvocationAction:[[[OCMNotificationPoster alloc] initWithNotification:aNotification] autorelease]];
 	return self;
 }
 
 - (id)andCall:(SEL)selector onObject:(id)anObject
 {
+    [self setInitTarget:self];
     [[self stub] addInvocationAction:[[[OCMIndirectReturnValueProvider alloc] initWithProvider:anObject andSelector:selector] autorelease]];
 	return self;
 }
 
 - (id)andDo:(void (^)(NSInvocation *))aBlock 
 {
+    [self setInitTarget:self];
     [[self stub] addInvocationAction:[[[OCMBlockCaller alloc] initWithCallBlock:aBlock] autorelease]];
     return self;
 }
 
 - (id)andForwardToRealObject
 {
+    [self setInitTarget:self];
     [[self stub] addInvocationAction:[[[OCMRealObjectForwarder alloc] init] autorelease]];
     return self;
 }

--- a/Source/OCMock/OCMVerifier.m
+++ b/Source/OCMock/OCMVerifier.m
@@ -35,6 +35,7 @@
 
 - (instancetype)withQuantifier:(OCMQuantifier *)quantifier
 {
+    [self setInitTarget:self];
     [self setQuantifier:quantifier];
     return self;
 }

--- a/Source/OCMock/OCMockObject.m
+++ b/Source/OCMock/OCMockObject.m
@@ -318,6 +318,12 @@
     {
         OCMRecorder *recorder = [[OCMMacroState globalState] recorder];
         [recorder setMockObject:self];
+        // If the initTarget has not been set then this is the first call through the
+        // recorder so we set it to the mock object.
+        if (![recorder initTarget])
+        {
+            [recorder setInitTarget:self];
+        }
         return recorder;
     }
     return nil;

--- a/Source/OCMock/OCPartialMockObject.m
+++ b/Source/OCMock/OCPartialMockObject.m
@@ -104,7 +104,30 @@
 
 - (void)handleUnRecordedInvocation:(NSInvocation *)anInvocation
 {
+	// In the case of an init that is called on a mock we must return the mock instance and
+	// not the realObject if the underlying init returns the realObject because at the call site
+	// ARC will have retained the target and the release/retain count must balance. If we return
+	// the realObject, then realObject will be over released and the mock will leak. Equally if
+	// we are called on the realObject we need to make sure not to return the mock.
+	id targetReceivingInit = nil;
+	if (OCMIsInvocationInitFamily(anInvocation))
+	{
+		targetReceivingInit = [anInvocation target];
+		[realObject retain];
+	}
 	[anInvocation invokeWithTarget:realObject];
+	if (targetReceivingInit)
+	{
+		id returnVal;
+		[anInvocation getReturnValue:&returnVal];
+		if (returnVal == realObject)
+		{
+			[anInvocation setReturnValue:&self];
+			[realObject release];
+			[self retain];
+		}
+		[targetReceivingInit release];
+	}
 }
 
 

--- a/Source/OCMockTests/OCMockObjectMacroTests.m
+++ b/Source/OCMockTests/OCMockObjectMacroTests.m
@@ -477,4 +477,27 @@
     XCTAssertEqualObjects(@"f", [mock commonPrefixWithString:@"foo" options:NSCaseInsensitiveSearch]);
 }
 
+- (void)testInitWithRecorderMethodsBeingPassedThroughMock
+{
+    // Because of the way the macros work, you can call recorder methods on the mock and they
+    // will work correctly. Technically these are a mix of old syntax and new.
+    // If these test fail we expect a crash.
+    // Note that the andReturn:nil has to be the first stub so that there is a return value.
+    id mock = OCMClassMock([NSString class]);
+    OCMStub([[mock andReturn:nil] initWithString:OCMOCK_ANY]);
+    OCMStub([[mock ignoringNonObjectArgs] initWithString:OCMOCK_ANY]);
+    OCMStub([[mock andReturnValue:nil] initWithString:OCMOCK_ANY]);
+    OCMStub([[mock andThrow:nil] initWithString:OCMOCK_ANY]);
+    OCMStub([[mock andPost:nil] initWithString:OCMOCK_ANY]);
+    OCMStub([[mock andCall:nil onObject:nil] initWithString:OCMOCK_ANY]);
+    OCMStub([[mock andDo:nil] initWithString:OCMOCK_ANY]);
+    OCMStub([[mock andForwardToRealObject] initWithString:OCMOCK_ANY]);
+    OCMExpect([[mock never] initWithString:OCMOCK_ANY]);
+    __unused id value = [mock initWithString:@"hello"];
+    _OCMVerify([[mock withQuantifier:nil] initWithString:OCMOCK_ANY]);
+
+    // Test multiple levels of recorder methods.
+    OCMStub([[[[mock ignoringNonObjectArgs] andReturn:nil] andThrow:nil] initWithString:OCMOCK_ANY]);
+}
+
 @end


### PR DESCRIPTION
Previously OCMockObjects were being leaked when init* methods were being stubbed.
Init method invocations are required to return an object to be considered part of the init method family (https://clang.llvm.org/docs/AutomaticReferenceCounting.html#method-families).

We verify that it is an init method by looking for the init prefix and verifying that it returns an id.