### PR TITLE
Catches references to self when not using macros.

### DIFF
--- a/Source/OCMock/OCMStubRecorder.m
+++ b/Source/OCMock/OCMStubRecorder.m
@@ -51,44 +51,46 @@
 
 - (id)andReturn:(id)anObject
 {
-	[[self stub] addInvocationAction:[[[OCMObjectReturnValueProvider alloc] initWithValue:anObject] autorelease]];
-	return self;
+    Class returnValueProviderClass;
+    if (anObject == mockObject)
+    {
+        returnValueProviderClass = [OCMNonRetainingObjectReturnValueProvider class];
+    } else
+    {
+        returnValueProviderClass = [OCMObjectReturnValueProvider class];
+    }
+    [[self stub] addInvocationAction:[[[returnValueProviderClass alloc] initWithValue:anObject] autorelease]];
+    return self;
 }
 
 - (id)andReturnValue:(NSValue *)aValue
 {
     [[self stub] addInvocationAction:[[[OCMBoxedReturnValueProvider alloc] initWithValue:aValue] autorelease]];
-	return self;
-}
-
-- (id)andReturnMockObject
-{
-	[[self stub] addInvocationAction:[[[OCMNonRetainingObjectReturnValueProvider alloc] initWithValue:mockObject] autorelease]];
-	return self;
+	  return self;
 }
 
 - (id)andThrow:(NSException *)anException
 {
     [[self stub] addInvocationAction:[[[OCMExceptionReturnValueProvider alloc] initWithValue:anException] autorelease]];
-	return self;
+	  return self;
 }
 
 - (id)andPost:(NSNotification *)aNotification
 {
     [[self stub] addInvocationAction:[[[OCMNotificationPoster alloc] initWithNotification:aNotification] autorelease]];
-	return self;
+	  return self;
 }
 
 - (id)andCall:(SEL)selector onObject:(id)anObject
 {
     [[self stub] addInvocationAction:[[[OCMIndirectReturnValueProvider alloc] initWithProvider:anObject andSelector:selector] autorelease]];
-	return self;
+	  return self;
 }
 
 - (id)andDo:(void (^)(NSInvocation *))aBlock 
 {
     [[self stub] addInvocationAction:[[[OCMBlockCaller alloc] initWithCallBlock:aBlock] autorelease]];
-	return self;
+	  return self;
 }
 
 - (id)andForwardToRealObject
@@ -122,7 +124,7 @@
         {
             id objValue = nil;
             [aValue getValue:&objValue];
-            return (objValue == mockObject) ? [self andReturnMockObject] : [self andReturn:objValue];
+            return [self andReturn:objValue];
         }
         else
         {

--- a/Source/OCMockTests/OCMockObjectTests.m
+++ b/Source/OCMockTests/OCMockObjectTests.m
@@ -214,7 +214,6 @@ static NSString *TestNotification = @"TestNotification";
 	mock = [OCMockObject mockForClass:[NSString class]];
 }
 
-
 #pragma mark    accepting stubbed methods / rejecting methods not stubbed
 
 - (void)testAcceptsStubbedMethod
@@ -577,6 +576,18 @@ static NSString *TestNotification = @"TestNotification";
 {
     @autoreleasepool {
         id mockWithShortLifetime = OCMClassMock([TestClassWithClassMethod class]);
+        [[[mockWithShortLifetime stub] andReturn:@"bar"] stringValue];
+        [[[mockWithShortLifetime stub] andReturn:mockWithShortLifetime] shared];
+    }
+    id singleton = [TestClassWithClassMethod shared];
+
+    XCTAssertEqualObjects(@"foo", [singleton stringValue], @"Should return value from real implementation (because shared is not stubbed anymore).");
+}
+
+- (void)testReturningMockFromMethodItStubsDoesntCreateRetainCycleUsingMacros
+{
+    @autoreleasepool {
+        id mockWithShortLifetime = OCMClassMock([TestClassWithClassMethod class]);
         OCMStub([mockWithShortLifetime stringValue]).andReturn(@"bar");
         OCMStub([mockWithShortLifetime shared]).andReturn(mockWithShortLifetime);
     }
@@ -584,6 +595,7 @@ static NSString *TestNotification = @"TestNotification";
     
     XCTAssertEqualObjects(@"foo", [singleton stringValue], @"Should return value from real implementation (because shared is not stubbed anymore).");
 }
+
 
 
 #pragma mark    beyond stubbing: raising exceptions, posting notifications, etc.


### PR DESCRIPTION
Previous code would only catch references to self when using the OCMStub/OCMExpect macros.
Now we avoid self referential retain loops if you use the `[[[foo stub] andReturn:foo] sharedInstance]` API.