### PR TITLE
Clean up descriptions

### DIFF
--- a/Source/OCMock/OCClassMockObject.m
+++ b/Source/OCMock/OCClassMockObject.m
@@ -42,7 +42,7 @@
 
 - (NSString *)description
 {
-	return [NSString stringWithFormat:@"OCMockObject(%@)", NSStringFromClass(mockedClass)];
+	return [NSString stringWithFormat:@"OCClassMockObject(%@)", NSStringFromClass(mockedClass)];
 }
 
 - (Class)mockedClass

--- a/Source/OCMock/OCObserverMockObject.m
+++ b/Source/OCMock/OCObserverMockObject.m
@@ -53,7 +53,7 @@
 
 - (NSString *)description
 {
-	return @"OCMockObserver";
+	return @"OCObserverMockObject";
 }
 
 - (void)setExpectationOrderMatters:(BOOL)flag

--- a/Source/OCMock/OCProtocolMockObject.m
+++ b/Source/OCMock/OCProtocolMockObject.m
@@ -33,7 +33,7 @@
 - (NSString *)description
 {
     const char* name = protocol_getName(mockedProtocol);
-    return [NSString stringWithFormat:@"OCMockObject(%s)", name];
+    return [NSString stringWithFormat:@"OCProtocolMockObject(%s)", name];
 }
 
 #pragma mark  Proxy API

--- a/Source/OCMockTests/OCMockObjectPartialMocksTests.m
+++ b/Source/OCMockTests/OCMockObjectPartialMocksTests.m
@@ -174,6 +174,13 @@ static NSUInteger initializeCallCount = 0;
 
 @implementation OCMockObjectPartialMocksTests
 
+- (void)testDescription
+{
+    TestClassWithSimpleMethod *object = [[TestClassWithSimpleMethod alloc] init];
+    id mock = [OCMockObject partialMockForObject:object];
+    XCTAssertEqualObjects([mock description], @"OCPartialMockObject(TestClassWithSimpleMethod)");
+}
+
 #pragma mark   Tests for stubbing with partial mocks
 
 - (void)testStubsMethodsOnPartialMock

--- a/Source/OCMockTests/OCMockObjectProtocolMocksTests.m
+++ b/Source/OCMockTests/OCMockObjectProtocolMocksTests.m
@@ -71,10 +71,10 @@ typedef InterfaceForTypedef* PointerTypedefInterface;
     [mock verify];
 }
 
-- (void)testSetsCorrectNameForProtocolMockObjects
+- (void)testDescription
 {
     id mock = [OCMockObject mockForProtocol:@protocol(NSLocking)];
-    XCTAssertEqualObjects(@"OCMockObject(NSLocking)", [mock description], @"Should have returned correct description.");
+    XCTAssertEqualObjects([mock description], @"OCProtocolMockObject(NSLocking)");
 }
 
 - (void)testRaisesWhenUnknownMethodIsCalledOnProtocol

--- a/Source/OCMockTests/OCMockObjectTests.m
+++ b/Source/OCMockTests/OCMockObjectTests.m
@@ -214,6 +214,11 @@ static NSString *TestNotification = @"TestNotification";
 	mock = [OCMockObject mockForClass:[NSString class]];
 }
 
+- (void)testDescription
+{
+    XCTAssertEqualObjects([mock description], @"OCClassMockObject(NSString)");
+}
+
 #pragma mark    accepting stubbed methods / rejecting methods not stubbed
 
 - (void)testAcceptsStubbedMethod


### PR DESCRIPTION
Make descriptions match the object type they are describing.

Descriptions previously often had a bad class name.