### PR TITLE
Allow expectation to complete in test

### DIFF
--- a/Source/OCMockTests/OCMockObjectTests.m
+++ b/Source/OCMockTests/OCMockObjectTests.m
@@ -1005,6 +1005,7 @@ static NSString *TestNotification = @"TestNotification";
     
 	[[mock expect] lowercaseString];
 	XCTAssertThrows([mock verify], @"Should have raised an exception because method was not called in time.");
+	[mock verifyWithDelay:1];
 }
 
 - (void)testFailsVerifyExpectedMethodsWithDelay


### PR DESCRIPTION
Right now there is a chance that the async code will run while another test is executing.

This allows the expectation to complete before starting another test.