### PR TITLE
Remove unneeded dealloc from OCPartialMockObject

### DIFF
--- a/Source/OCMock/OCPartialMockObject.m
+++ b/Source/OCMock/OCPartialMockObject.m
@@ -38,13 +38,6 @@
 	return self;
 }
 
-- (void)dealloc
-{
-	[self stopMocking];
-	[realObject release];
-	[super dealloc];
-}
-
 - (NSString *)description
 {
 	return [NSString stringWithFormat:@"OCPartialMockObject(%@)", NSStringFromClass(mockedClass)];


### PR DESCRIPTION
[super dealloc] was already calling stopMocking and stopMocking was setting realObject to nil, so this code is unneeded.