### PR TITLE
Better exception when attempting to mock NSObject method with macro.

### DIFF
--- a/Source/OCMock/OCMMacroState.m
+++ b/Source/OCMock/OCMMacroState.m
@@ -45,7 +45,10 @@ static NSString *const OCMGlobalStateKey = @"OCMGlobalStateKey";
 	if([recorder wasUsed] == NO)
 	{
 		[NSException raise:NSInternalInconsistencyException
-					format:@"Mock object was not used in OCMStub/OCMExpect/OCMReject. Did you accidentally use a real object?"];
+					format:@"Did not record an invocation in OCMStub/OCMExpect/OCMReject.\n"
+						   @"Possible causes are:\n"
+						   @"- The receiver is not a mock object.\n"
+						   @"- The selector conflicts with a selector implemented by OCMStubRecorder/OCMExpectationRecorder."];
 	}
     return recorder;
 }

--- a/Source/OCMockTests/OCMockObjectMacroTests.m
+++ b/Source/OCMockTests/OCMockObjectMacroTests.m
@@ -337,32 +337,53 @@
 	
 	XCTAssertThrowsSpecificNamed(OCMVerify([realObject addObject:@"foo"]),
 	        NSException, NSInternalInconsistencyException, @"should throw NSInternalInconsistencyException exception");
-}
 
-- (void)testShouldThrowExceptionWhenNotUsingMockInStub
-{
-	id realObject = [NSMutableArray array];
-	
 	XCTAssertThrowsSpecificNamed(OCMStub([realObject addObject:@"foo"]),
 	        NSException, NSInternalInconsistencyException, @"should throw NSInternalInconsistencyException exception");
-}
 
-- (void)testShouldThrowExceptionWhenNotUsingMockInExpect
-{
-    id realObject = [NSMutableArray array];
-
-    XCTAssertThrowsSpecificNamed(OCMExpect([realObject addObject:@"foo"]),
+	XCTAssertThrowsSpecificNamed(OCMExpect([realObject addObject:@"foo"]),
             NSException, NSInternalInconsistencyException, @"should throw NSInternalInconsistencyException exception");
-}
 
-- (void)testShouldThrowExceptionWhenNotUsingMockInReject
-{
-	id realObject = [NSMutableArray array];
-	
 	XCTAssertThrowsSpecificNamed(OCMReject([realObject addObject:@"foo"]),
             NSException, NSInternalInconsistencyException, @"should throw NSInternalInconsistencyException exception");
+
+	// Verify that the exception string contains something close to what we want people to be aware of.
+	@try
+	{
+		OCMStub([realObject addObject:@"foo"]);
+	}
+	@catch (NSException *e)
+	{
+		XCTAssertTrue([[e reason] containsString:@"The receiver is not a mock object."]);
+	}
 }
 
+- (void)testShouldThrowExceptionWhenAttemptingToMockNSObjectMethod
+{
+	id mock = OCMClassMock([NSString class]);
+
+	XCTAssertThrowsSpecificNamed(OCMVerify([mock description]),
+			NSException, NSInternalInconsistencyException, @"should throw NSInternalInconsistencyException exception");
+
+	XCTAssertThrowsSpecificNamed(OCMStub([mock description]),
+			NSException, NSInternalInconsistencyException, @"should throw NSInternalInconsistencyException exception");
+
+    XCTAssertThrowsSpecificNamed(OCMExpect([mock description]),
+            NSException, NSInternalInconsistencyException, @"should throw NSInternalInconsistencyException exception");
+
+	XCTAssertThrowsSpecificNamed(OCMReject([mock description]),
+			  NSException, NSInternalInconsistencyException, @"should throw NSInternalInconsistencyException exception");
+
+	// Verify that the exception string contains something close to what we want people to be aware of.
+	@try
+	{
+		OCMStub([mock description]);
+	}
+	@catch (NSException *e)
+	{
+		XCTAssertTrue([[e reason] containsString:@"The selector conflicts with a selector implemented by OCMStubRecorder/OCMExpectationRecorder."]);
+	}
+}
 
 - (void)testCanExplicitlySelectClassMethodForStubs
 {


### PR DESCRIPTION
The exception message provided when attempting to mock an NSObject method (like hash)
with a macro is confusing. The updated text is much clearer as to possible causes.