### PR TITLE
Add exception for mocking class methods after stopMocking called.

### DIFF
--- a/Source/OCMock/OCClassMockObject.h
+++ b/Source/OCMock/OCClassMockObject.h
@@ -21,6 +21,7 @@
     Class  mockedClass;
     Class  originalMetaClass;
     Class  classCreatedForNewMetaClass;
+    BOOL   stoppedMocking;
 }
 
 - (id)initWithClass:(Class)aClass;

--- a/Source/OCMock/OCClassMockObject.m
+++ b/Source/OCMock/OCClassMockObject.m
@@ -50,10 +50,16 @@
 	return mockedClass;
 }
 
+- (BOOL)mockingHasBeenStopped
+{
+    return stoppedMocking;
+}
+
 #pragma mark  Extending/overriding superclass behaviour
 
 - (void)stopMocking
 {
+    stoppedMocking = YES;
     if(originalMetaClass != nil)
     {
         [self stopMockingClassMethods];
@@ -78,6 +84,10 @@
 
 - (void)addStub:(OCMInvocationStub *)aStub
 {
+    if ([self mockingHasBeenStopped])
+    {
+        [NSException raise:NSInternalInconsistencyException format:@"Cannot add stubs or expectations on %@ at %p. This occurs when a mock object is used after `stopMocking` has been called on it.", self, self];
+    }
     [super addStub:aStub];
     if([aStub recordedAsClassMethod])
         [self setupForwarderForClassMethodSelector:[[aStub recordedInvocation] selector]];

--- a/Source/OCMockTests/OCMockObjectClassMethodMockingTests.m
+++ b/Source/OCMockTests/OCMockObjectClassMethodMockingTests.m
@@ -368,4 +368,11 @@ static NSUInteger initializeCallCount = 0;
     XCTAssertNil(weakArgument);
 }
 
+- (void)testShouldThrowAssertionWhenStoppedMockHasClassMethodStubbed
+{
+    id mock = OCMClassMock([TestClassWithClassMethods class]);
+    [mock stopMocking];
+    XCTAssertThrowsSpecificNamed(OCMStub([mock foo]).andReturn(@"hello"), NSException, NSInternalInconsistencyException);
+}
+
 @end

--- a/Source/OCMockTests/OCMockObjectTests.m
+++ b/Source/OCMockTests/OCMockObjectTests.m
@@ -473,6 +473,12 @@ static NSString *TestNotification = @"TestNotification";
     XCTAssertTrue(blockWasInvoked, @"Should not have ignored the block argument.");
 }
 
+- (void)testShouldThrowAssertionWhenStoppedMockHasInstanceMethodStubbed
+{
+    [mock stopMocking];
+    XCTAssertThrowsSpecificNamed([[mock stub] rangeOfString:@"foo" options:0], NSException, NSInternalInconsistencyException);
+}
+
 
 #pragma mark    returning values from stubbed methods
 


### PR DESCRIPTION
Adding class methods after stopMocking was called could cause extremely confusing results
including crashes at runtime.