### PR TITLE
Better error message for OCMVerify of some methods on partial mocks.

### DIFF
--- a/Source/OCMock/OCMockObject.m
+++ b/Source/OCMock/OCMockObject.m
@@ -301,9 +301,15 @@
             case 1:  actualDescription = @"invoked once"; break;
             default: actualDescription = [NSString stringWithFormat:@"invoked %lu times", (unsigned long)count]; break;
         }
-        
-        NSString *description = [NSString stringWithFormat:@"%@: Method %@ was %@; but was expected %@.",
-                                 [self description], [matcher description], actualDescription, [quantifier description]];
+
+        NSString *addedInstructions = @"";
+        // Hacky way of determining if we are a class mock or a partial mock.
+        if (class_getInstanceMethod(object_getClass(self), @selector(realObject)))
+        {
+            addedInstructions = [NSString stringWithFormat:@"Adding a stub for `%@` may resolve the issue. ex: `OCMStub([foo %@]).andForwardToRealObject()`", [matcher description], [matcher description]];
+        }
+        NSString *description = [NSString stringWithFormat:@"%@: Method `%@` was %@; but was expected %@.%@",
+                                 [self description], [matcher description], actualDescription, [quantifier description], addedInstructions];
         OCMReportFailure(location, description);
     }
 }

--- a/Source/OCMockTests/OCMockObjectPartialMocksTests.m
+++ b/Source/OCMockTests/OCMockObjectPartialMocksTests.m
@@ -139,6 +139,7 @@ static NSUInteger initializeCallCount = 0;
 @interface OCMockObjectPartialMocksTests : XCTestCase
 {
     int numKVOCallbacks;
+    NSString *expectedDescription;
 }
 
 @end
@@ -173,6 +174,18 @@ static NSUInteger initializeCallCount = 0;
 @end
 
 @implementation OCMockObjectPartialMocksTests
+
+- (void)recordFailureWithDescription:(NSString *)description inFile:(NSString *)filePath atLine:(NSUInteger)lineNumber expected:(BOOL)expected
+{
+	// By setting expectedDescription we can test expected failures.
+	if (expectedDescription && [description containsString:expectedDescription])
+	{
+		 // Was an expected failure.
+		 expectedDescription = nil;
+		 return;
+	}
+	[super recordFailureWithDescription:description inFile:filePath atLine:lineNumber expected:expected];
+}
 
 - (void)testDescription
 {
@@ -608,5 +621,13 @@ static NSUInteger initializeCallCount = 0;
 	XCTAssertNoThrow([foo method1], @"Should have worked.");
 }
 
+- (void)testAttemptingToVerifyMethodImplementedByNSObjectUsingMacroThrows
+{
+	TestClassThatCallsSelf *realObject = [[TestClassThatCallsSelf alloc] init];
+	id mock = [OCMockObject partialMockForObject:realObject];
+	[realObject categoryMethod];
+	expectedDescription = @"Adding a stub";
+	OCMVerify([mock categoryMethod]);
+}
 
 @end


### PR DESCRIPTION
Fix for #408.

The error message is now:

`Selector '%@' can not be verified using OCMVerify(). Use OCMExpect() instead.`