### PR TITLE
Pass exceptions through macros

### DIFF
--- a/Source/OCMock/OCMMacroState.h
+++ b/Source/OCMock/OCMMacroState.h
@@ -26,6 +26,7 @@
 @interface OCMMacroState : NSObject
 {
     id recorder;
+    BOOL caughtException;
 }
 
 + (void)beginStubMacro;
@@ -47,5 +48,6 @@
 - (id)recorder;
 
 - (void)switchToClassMethod;
+- (void)setCaughtException;
 
 @end

--- a/Source/OCMock/OCMMacroState.m
+++ b/Source/OCMock/OCMMacroState.m
@@ -38,8 +38,9 @@ static NSString *const OCMGlobalStateKey = @"OCMGlobalStateKey";
     NSMutableDictionary *threadDictionary = [NSThread currentThread].threadDictionary;
     OCMMacroState *globalState = threadDictionary[OCMGlobalStateKey];
     OCMStubRecorder *recorder = [[(OCMStubRecorder *)[globalState recorder] retain] autorelease];
+    BOOL caughtException = [globalState caughtException];
     [threadDictionary removeObjectForKey:OCMGlobalStateKey];
-	if([recorder wasUsed] == NO)
+	if(caughtException == NO && [recorder wasUsed] == NO)
 	{
 		[NSException raise:NSInternalInconsistencyException
 					format:@"Did not record an invocation in OCMStub/OCMExpect/OCMReject.\n"
@@ -103,8 +104,9 @@ static NSString *const OCMGlobalStateKey = @"OCMGlobalStateKey";
 	NSMutableDictionary *threadDictionary = [NSThread currentThread].threadDictionary;
 	OCMMacroState *globalState = threadDictionary[OCMGlobalStateKey];
 	OCMVerifier *verifier = [[(OCMVerifier *)[globalState recorder] retain] autorelease];
+  BOOL caughtException = [globalState caughtException];
 	[threadDictionary removeObjectForKey:OCMGlobalStateKey];
-	if([verifier wasUsed] == NO)
+	if(caughtException == NO && [verifier wasUsed] == NO)
     {
         [NSException raise:NSInternalInconsistencyException
                     format:@"Did not record an invocation in OCMVerify.\n"
@@ -152,6 +154,16 @@ static NSString *const OCMGlobalStateKey = @"OCMGlobalStateKey";
 {
     return recorder;
 }
+
+- (BOOL)caughtException
+{
+    return caughtException;
+}
+
+- (void)setCaughtException
+ {
+    caughtException = YES;
+ }
 
 
 #pragma mark  Changing the recorder

--- a/Source/OCMock/OCMVerifier.m
+++ b/Source/OCMock/OCMVerifier.m
@@ -23,6 +23,8 @@
 
 - (id)init
 {
+    if(invocationMatcher != nil)
+        [NSException raise:NSInternalInconsistencyException format:@"** Method init invoked twice on verifier. Are you trying to verify the init method? This is currently not supported."];
     if ((self = [super init]))
     {
         invocationMatcher = [[OCMInvocationMatcher alloc] init];

--- a/Source/OCMock/OCMock.h
+++ b/Source/OCMock/OCMock.h
@@ -52,6 +52,9 @@
         OCMStubRecorder *recorder = nil; \
         @try{ \
             invocation; \
+        }@catch(...){ \
+            [[OCMMacroState globalState] setCaughtException]; \
+            @throw; \
         }@finally{ \
             recorder = [OCMMacroState endStubMacro]; \
         } \
@@ -66,6 +69,9 @@
         OCMStubRecorder *recorder = nil; \
         @try{ \
             invocation; \
+        }@catch(...){ \
+            [[OCMMacroState globalState] setCaughtException]; \
+            @throw; \
         }@finally{ \
             recorder = [OCMMacroState endExpectMacro]; \
         } \
@@ -80,6 +86,9 @@
         OCMStubRecorder *recorder = nil; \
         @try{ \
             invocation; \
+        }@catch(...){ \
+            [[OCMMacroState globalState] setCaughtException]; \
+            @throw; \
         }@finally{ \
             recorder = [OCMMacroState endRejectMacro]; \
         } \
@@ -111,6 +120,9 @@
         [OCMMacroState beginVerifyMacroAtLocation:OCMMakeLocation(self, __FILE__, __LINE__)]; \
         @try{ \
             invocation; \
+        }@catch(...){ \
+            [[OCMMacroState globalState] setCaughtException]; \
+            @throw; \
         }@finally{ \
             [OCMMacroState endVerifyMacro]; \
         } \
@@ -123,6 +135,9 @@
         [OCMMacroState beginVerifyMacroAtLocation:OCMMakeLocation(self, __FILE__, __LINE__) withQuantifier:quantifier]; \
         @try{ \
            invocation; \
+        }@catch(...){ \
+            [[OCMMacroState globalState] setCaughtException]; \
+            @throw; \
         }@finally{ \
             [OCMMacroState endVerifyMacro]; \
         } \

--- a/Source/OCMockTests/OCMockObjectMacroTests.m
+++ b/Source/OCMockTests/OCMockObjectMacroTests.m
@@ -503,4 +503,61 @@
     OCMStub([[[[mock ignoringNonObjectArgs] andReturn:nil] andThrow:nil] initWithString:OCMOCK_ANY]);
 }
 
+- (void)testMacrosPassExceptionsThroughOnStub {
+    id mock = OCMClassMock([TestClassForMacroTesting class]);
+    BOOL caughtException = NO;
+    @try
+    {
+        OCMStub([mock init]).andReturn(mock);
+    }
+    @catch(NSException *exception)
+    {
+        caughtException = YES;
+        XCTAssertEqualObjects(exception.name, NSInternalInconsistencyException);
+        XCTAssertTrue([exception.reason containsString:@"Method init invoked twice on stub recorder"]);
+    }
+    @finally
+    {
+        XCTAssertTrue(caughtException, @"An exception should have been thrown.");
+    }
+}
+
+- (void)testMacrosPassExceptionsThroughOnExpect {
+    id mock = OCMClassMock([TestClassForMacroTesting class]);
+    BOOL caughtException = NO;
+    @try
+    {
+        OCMExpect([mock init]).andReturn(mock);
+    }
+    @catch(NSException *exception)
+    {
+        caughtException = YES;
+        XCTAssertEqualObjects(exception.name, NSInternalInconsistencyException);
+        XCTAssertTrue([exception.reason containsString:@"Method init invoked twice on stub recorder"]);
+    }
+    @finally
+    {
+        XCTAssertTrue(caughtException, @"An exception should have been thrown.");
+    }
+}
+
+- (void)testMacrosPassExceptionsThroughOnVerify {
+    id mock = OCMClassMock([TestClassForMacroTesting class]);
+    BOOL caughtException = NO;
+    @try
+    {
+        OCMVerify([mock init]);
+    }
+    @catch(NSException *exception)
+    {
+        caughtException = YES;
+        XCTAssertEqualObjects(exception.name, NSInternalInconsistencyException);
+        XCTAssertTrue([exception.reason containsString:@"Method init invoked twice on verifier"]);
+    }
+    @finally
+    {
+        XCTAssertTrue(caughtException, @"An exception should have been thrown.");
+    }
+}
+
 @end


### PR DESCRIPTION
If an exception was thrown in a `OCMExpect/OCMStub/OCMVerify` macro it would often
get replaced by a confusing error message in the `@finally` blocks of the macro.
Now the original exception is passed through.

As part of this discovered that `OCMVerifier` did not block having init called on it
twice like `OCMStubRecorder`.