### PR TITLE
Blacklists `resolveClassMethod:` from having a forwarder set up for it.

### DIFF
--- a/Source/OCMock/OCClassMockObject.m
+++ b/Source/OCMock/OCClassMockObject.m
@@ -123,7 +123,7 @@
 
     /* adding forwarder for most class methods (instance methods on meta class) to allow for verify after run */
     NSArray *methodBlackList = @[@"class", @"forwardingTargetForSelector:", @"methodSignatureForSelector:", @"forwardInvocation:", @"isBlock",
-            @"instanceMethodForwarderForSelector:", @"instanceMethodSignatureForSelector:"];
+            @"instanceMethodForwarderForSelector:", @"instanceMethodSignatureForSelector:", @"resolveClassMethod:"];
     [NSObject enumerateMethodsInClass:originalMetaClass usingBlock:^(Class cls, SEL sel) {
         if((cls == object_getClass([NSObject class])) || (cls == [NSObject class]) || (cls == object_getClass(cls)))
             return;

--- a/Source/OCMockTests/OCMockObjectRuntimeTests.m
+++ b/Source/OCMockTests/OCMockObjectRuntimeTests.m
@@ -109,6 +109,28 @@ typedef NSString TypedefString;
 
 @end
 
+@interface TestClassWithResolveMethods : NSObject
+@end
+
+@implementation TestClassWithResolveMethods
+
+- (void)instanceMethod {
+}
+
++ (BOOL)resolveInstanceMethod:(SEL)sel
+{
+  return [super resolveInstanceMethod:sel];
+}
+
++ (void)classMethod {
+}
+
++ (BOOL)resolveClassMethod:(SEL)sel
+{
+  return [super resolveClassMethod:sel];
+}
+
+@end
 
 #pragma mark   Tests for interaction with runtime and foundation conventions
 
@@ -283,6 +305,11 @@ typedef NSString TypedefString;
     XCTAssertEqual(numClassesBefore, numClassesAfter, @"Should have disposed dynamically generated classes.");
 }
 
+- (void)testClassesWithResolveMethodsCanBeMocked
+{
+    // If this test fails it will crash due to recursion.
+    __unused id mock = OCMClassMock([TestClassWithResolveMethods class]);
+}
 
 #pragma mark    verify mocks work properly when mocking init
 


### PR DESCRIPTION
Fix for #415