### PR TITLE
Clean up warning regarding OCMVerify due to init issue

### DIFF
--- a/Source/OCMockTests/OCMockObjectMacroTests.m
+++ b/Source/OCMockTests/OCMockObjectMacroTests.m
@@ -538,7 +538,8 @@
     id mock = OCMClassMock([TestClassForMacroTesting class]);
     @try
     {
-        OCMVerify([mock init]);
+        // Using _OCMVerify here because of https://github.com/erikdoe/ocmock/issues/390
+        _OCMVerify([mock init]);
         XCTFail(@"An exception should have been thrown.");
     }
     @catch(NSException *exception)


### PR DESCRIPTION
See #390 for details on init issue.

Not sure if you'd prefer to keep the warning or mask it for the time being with this fix.