### PR TITLE
Update CI to Xcode 11.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode11.2
+osx_image: xcode11.5
 before_install:
     - gem install xcpretty -N --quiet
 script: make ci

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 
 BUILD_DIR = OBJROOT="$(CURDIR)/build" SYMROOT="$(CURDIR)/build"
 SHELL = /bin/bash -e -o pipefail
-IOS32 = -scheme OCMockLib -destination 'platform=iOS Simulator,OS=10.3.1,name=iPhone 5' $(BUILD_DIR)
+IOS32 = -scheme OCMockLib -destination 'platform=iOS Simulator,OS=10.3.1,name=iPad (5th generation)' $(BUILD_DIR)
 IOS64 = -scheme OCMockLib -destination 'platform=iOS Simulator,OS=latest,name=iPhone 11' $(BUILD_DIR)
 MACOSX = -scheme OCMock -sdk macosx $(BUILD_DIR)
 XCODEBUILD = xcodebuild -project "$(CURDIR)/Source/OCMock.xcodeproj"


### PR DESCRIPTION
Update the Travis CI configuration to leverage the Xcode 11.5 environment. 

Upgrading from Xcode 11.2.1, here are the relevant release notes:
* [Xcode 11.3](https://developer.apple.com/documentation/xcode_release_notes/xcode_11_3_release_notes)
* [Xcode 11.3.1](https://developer.apple.com/documentation/xcode_release_notes/xcode_11_3_1_release_notes)
* [Xcode 11.4](https://developer.apple.com/documentation/xcode_release_notes/xcode_11_4_release_notes)
* [Xcode 11.4.1](https://developer.apple.com/documentation/xcode_release_notes/xcode_11_4_1_release_notes)
* [Xcode 11.5](https://developer.apple.com/documentation/xcode_release_notes/xcode_11_5_release_notes)