### PR TITLE
Suppress a warning in OCMockObjectMacroTests

### DIFF
--- a/Source/OCMockTests/OCMockObjectMacroTests.m
+++ b/Source/OCMockTests/OCMockObjectMacroTests.m
@@ -538,7 +538,7 @@
     id mock = OCMClassMock([TestClassForMacroTesting class]);
     @try
     {
-        OCMVerify([mock init]);
+        OCMVerify([[mock init] description]);
         XCTFail(@"An exception should have been thrown.");
     }
     @catch(NSException *exception)


### PR DESCRIPTION
This test cannot be ran with these flags on: `-Werror,-Wunused-value`.
The full error looks like this:
```
stderr: OCMock/src/Source/OCMockTests/OCMockObjectMacroTests.m:541:19: error: expression result unused [-Werror,-Wunused-value]
        OCMVerify([mock init]);
                  ^~~~~~~~~~~
OCMock/src/Source/OCMock/OCMock.h:152:93: note: expanded from macro 'OCMVerify'
#define OCMVerify(...) _OCMVerify_X(,##__VA_ARGS__, _OCMVerify_2(__VA_ARGS__), _OCMVerify_1(__VA_ARGS__))
                                                                                            ^~~~~~~~~~~
OCMock/src/Source/OCMock/OCMock.h:149:52: note: expanded from macro '_OCMVerify_1'
#define _OCMVerify_1(A)                 _OCMVerify(A)
                                                   ^
OCMock/src/Source/OCMock/OCMock.h:122:13: note: expanded from macro '_OCMVerify'
            invocation; \
            ^~~~~~~~~~
OCMock/src/Source/OCMock/OCMock.h:161:5: note: expanded from macro '_OCMSilenceWarnings'
    macro \
    ^~~~~
OCMock/src/Source/OCMock/OCMock.h:151:41: note: expanded from macro '_OCMVerify_X'
#define _OCMVerify_X(x,A,B,FUNC, ...)   FUNC
```

Basically the issue is that the result of `init` is not used. So adding some random method call should suppress the warning and fix the build.