### PR TITLE
Use forward declaration in OCMVerifier.h

### DIFF
--- a/Source/OCMock/OCMVerifier.h
+++ b/Source/OCMock/OCMVerifier.h
@@ -15,9 +15,9 @@
  */
 
 #import "OCMRecorder.h"
-#import "OCMLocation.h"
-#import "OCMQuantifier.h"
 
+@class OCMLocation;
+@class OCMQuantifier;
 
 @interface OCMVerifier : OCMRecorder
 

--- a/Source/OCMock/OCMVerifier.m
+++ b/Source/OCMock/OCMVerifier.m
@@ -17,6 +17,8 @@
 #import "OCMVerifier.h"
 #import "OCMockObject.h"
 #import "OCMInvocationMatcher.h"
+#import "OCMLocation.h"
+#import "OCMQuantifier.h"
 
 
 @implementation OCMVerifier


### PR DESCRIPTION
It's better to forward declare these instead of import them directly per general best practice :)