### PR TITLE
Replace retain attributes with other memory management attributes

### DIFF
--- a/Examples/iPhoneExample/Classes/iPhoneExampleAppDelegate.h
+++ b/Examples/iPhoneExample/Classes/iPhoneExampleAppDelegate.h
@@ -14,8 +14,8 @@
     UINavigationController *navigationController;
 }
 
-@property (nonatomic, retain) IBOutlet UIWindow *window;
-@property (nonatomic, retain) IBOutlet UINavigationController *navigationController;
+@property (nonatomic, strong) IBOutlet UIWindow *window;
+@property (nonatomic, strong) IBOutlet UINavigationController *navigationController;
 
 @end
 

--- a/Source/OCMock/OCMVerifier.h
+++ b/Source/OCMock/OCMVerifier.h
@@ -21,8 +21,8 @@
 
 @interface OCMVerifier : OCMRecorder
 
-@property(retain) OCMLocation *location;
-@property(retain) OCMQuantifier *quantifier;
+@property(strong) OCMLocation *location;
+@property(strong) OCMQuantifier *quantifier;
 
 - (instancetype)withQuantifier:(OCMQuantifier *)quantifier;
 

--- a/Source/OCMockTests/OCMockObjectDynamicPropertyMockingTests.m
+++ b/Source/OCMockTests/OCMockObjectDynamicPropertyMockingTests.m
@@ -20,7 +20,7 @@
 #pragma mark   Helper classes
 
 @interface TestClassWithDynamicProperties : NSObject
-@property(nonatomic, retain) NSDictionary *anObject;
+@property(nonatomic, copy) NSDictionary *anObject;
 @property(nonatomic, assign) NSUInteger aUInt;
 @property(nonatomic, assign) NSInteger __aPrivateInt;
 @property(getter=customGetter, setter=customSetter:) NSDictionary *aCustomProperty;

--- a/Source/OCMockTests/OCMockObjectInternalTests.m
+++ b/Source/OCMockTests/OCMockObjectInternalTests.m
@@ -22,7 +22,7 @@
 
 @interface TestClassForInternalTests : NSObject
 
-@property (nonatomic, retain) NSString *title;
+@property (nonatomic, copy) NSString *title;
 
 - (void)doStuffWithClass:(Class)aClass;
 

--- a/Source/OCMockTests/OCMockObjectTests.m
+++ b/Source/OCMockTests/OCMockObjectTests.m
@@ -78,7 +78,7 @@ TestOpaque myOpaque;
 
 @interface TestClassWithProperty : NSObject
 
-@property (nonatomic, retain) NSString *title;
+@property (nonatomic, copy) NSString *title;
 
 @end
 


### PR DESCRIPTION
The retain attributes can be replaced by `strong` for most of the time in ARC world. Since they were introduced 4-6 years ago, I think for now we can refresh these by using these new attributes which are more common. 

It shouldn't change anything drastically and the tests are still passing.