### PR TITLE
Rename "wasUsed" to "ocm_wasUsed"

### DIFF
--- a/Source/OCMock/OCMExpectationRecorder.h
+++ b/Source/OCMock/OCMExpectationRecorder.h
@@ -16,6 +16,8 @@
 
 #import <OCMock/OCMock.h>
 
+// NB Any new methods in this class should be prefixed with `ocm_` to prevent potential clashes with
+// methods that are being stubbed in mock objects by clients.
 @interface OCMExpectationRecorder : OCMStubRecorder
 
 - (id)never;

--- a/Source/OCMock/OCMMacroState.m
+++ b/Source/OCMock/OCMMacroState.m
@@ -40,7 +40,7 @@ static NSString *const OCMGlobalStateKey = @"OCMGlobalStateKey";
     OCMStubRecorder *recorder = [[(OCMStubRecorder *)[globalState recorder] retain] autorelease];
     BOOL didThrow = [globalState invocationDidThrow];
     [threadDictionary removeObjectForKey:OCMGlobalStateKey];
-	if(didThrow == NO && [recorder wasUsed] == NO)
+	if(didThrow == NO && [recorder ocm_wasUsed] == NO)
 	{
 		[NSException raise:NSInternalInconsistencyException
 					format:@"Did not record an invocation in OCMStub/OCMExpect/OCMReject.\n"
@@ -106,7 +106,7 @@ static NSString *const OCMGlobalStateKey = @"OCMGlobalStateKey";
 	OCMVerifier *verifier = [[(OCMVerifier *)[globalState recorder] retain] autorelease];
     BOOL didThrow = [globalState invocationDidThrow];
 	[threadDictionary removeObjectForKey:OCMGlobalStateKey];
-	if(didThrow == NO && [verifier wasUsed] == NO)
+	if(didThrow == NO && [verifier ocm_wasUsed] == NO)
     {
         [NSException raise:NSInternalInconsistencyException
                     format:@"Did not record an invocation in OCMVerify.\n"

--- a/Source/OCMock/OCMObserverRecorder.h
+++ b/Source/OCMock/OCMObserverRecorder.h
@@ -29,6 +29,6 @@
 
 - (BOOL)argument:(id)expectedArg matchesArgument:(id)observedArg;
 
-- (BOOL)wasUsed;
+- (BOOL)ocm_wasUsed;
 
 @end

--- a/Source/OCMock/OCMObserverRecorder.m
+++ b/Source/OCMock/OCMObserverRecorder.m
@@ -38,7 +38,7 @@
 	[super dealloc];
 }
 
-- (BOOL)wasUsed
+- (BOOL)ocm_wasUsed
 {
 	return YES; // Needed for macro use, and recorder can only end up in macro state if it was used.
 }

--- a/Source/OCMock/OCMRecorder.h
+++ b/Source/OCMock/OCMRecorder.h
@@ -19,7 +19,8 @@
 @class OCMockObject;
 @class OCMInvocationMatcher;
 
-
+// NB Any new methods in this class should be prefixed with `ocm_` to prevent potential clashes with
+// methods that are being stubbed in mock objects by clients.
 @interface OCMRecorder : NSProxy
 {
     OCMockObject         *mockObject;
@@ -36,7 +37,7 @@
 - (void)setShouldReturnMockFromInit:(BOOL)flag;
 
 - (OCMInvocationMatcher *)invocationMatcher;
-- (BOOL)wasUsed;
+- (BOOL)ocm_wasUsed;
 
 - (id)classMethod;
 - (id)ignoringNonObjectArgs;

--- a/Source/OCMock/OCMRecorder.m
+++ b/Source/OCMock/OCMRecorder.m
@@ -65,7 +65,7 @@
     return invocationMatcher;
 }
 
-- (BOOL)wasUsed
+- (BOOL)ocm_wasUsed
 {
     return wasUsed;
 }

--- a/Source/OCMock/OCMStubRecorder.h
+++ b/Source/OCMock/OCMStubRecorder.h
@@ -18,6 +18,8 @@
 #import <OCMock/OCMFunctions.h>
 #import <objc/runtime.h>
 
+// NB Any new methods in this class should be prefixed with `ocm_` to prevent potential clashes with
+// methods that are being stubbed in mock objects by clients.
 @interface OCMStubRecorder : OCMRecorder
 
 - (id)andReturn:(id)anObject;

--- a/Source/OCMock/OCMVerifier.h
+++ b/Source/OCMock/OCMVerifier.h
@@ -19,6 +19,8 @@
 #import "OCMQuantifier.h"
 
 
+// NB Any new methods in this class should be prefixed with `ocm_` to prevent potential clashes with
+// methods that are being stubbed in mock objects by clients.
 @interface OCMVerifier : OCMRecorder
 
 @property(retain) OCMLocation *location;


### PR DESCRIPTION
Objects that we were mocking had a `wasUsed` field that prevented them from being easily mocked using `OCMStub`, `OCMExpect` etc.

All future methods in recorders should be prefixed with `ocm_ `to prevent potential conflicts.