### PR TITLE
Report reject macro failure properly

### DIFF
--- a/Source/OCMock/OCMExpectationRecorder.h
+++ b/Source/OCMock/OCMExpectationRecorder.h
@@ -18,6 +18,8 @@
 
 @interface OCMExpectationRecorder : OCMStubRecorder
 
+@property(retain) OCMLocation *location;
+
 - (id)never;
 
 @end

--- a/Source/OCMock/OCMExpectationRecorder.m
+++ b/Source/OCMock/OCMExpectationRecorder.m
@@ -39,6 +39,7 @@
 
 - (id)never
 {
+    [[self expectation] setLocation:[self location]];
     [[self expectation] setMatchAndReject:YES];
     return self;
 }
@@ -52,5 +53,10 @@
     [mockObject addExpectation:[self expectation]];
 }
 
+- (void)dealloc
+{
+    [_location release];
+    [super dealloc];
+}
 
 @end

--- a/Source/OCMock/OCMInvocationExpectation.h
+++ b/Source/OCMock/OCMInvocationExpectation.h
@@ -16,11 +16,15 @@
 
 #import "OCMInvocationStub.h"
 
+@class OCMLocation;
+
 @interface OCMInvocationExpectation : OCMInvocationStub
 {
     BOOL matchAndReject;
     BOOL isSatisfied;
 }
+
+@property(retain) OCMLocation *location;
 
 - (void)setMatchAndReject:(BOOL)flag;
 - (BOOL)isMatchAndReject;

--- a/Source/OCMock/OCMInvocationExpectation.m
+++ b/Source/OCMock/OCMInvocationExpectation.m
@@ -15,6 +15,7 @@
  */
 
 #import "OCMInvocationExpectation.h"
+#import "OCMFunctionsPrivate.h"
 #import "NSInvocation+OCMAdditions.h"
 
 
@@ -44,13 +45,20 @@
     if(matchAndReject)
     {
         isSatisfied = NO;
-        [NSException raise:NSInternalInconsistencyException format:@"%@: explicitly disallowed method invoked: %@",
-                [self description], [anInvocation invocationDescription]];
+        NSString *description = [NSString stringWithFormat:@"%@: explicitly disallowed method invoked: %@",
+                                 [self description], [anInvocation invocationDescription]];
+        OCMReportFailure([self location], description);
     }
     else
     {
         isSatisfied = YES;
     }
+}
+
+- (void)dealloc
+{
+    [_location release];
+    [super dealloc];
 }
 
 @end

--- a/Source/OCMock/OCMMacroState.h
+++ b/Source/OCMock/OCMMacroState.h
@@ -35,7 +35,7 @@
 + (void)beginExpectMacro;
 + (OCMStubRecorder *)endExpectMacro;
 
-+ (void)beginRejectMacro;
++ (void)beginRejectMacroAtLocation:(OCMLocation *)aLocation;
 + (OCMStubRecorder *)endRejectMacro;
 
 + (void)beginVerifyMacroAtLocation:(OCMLocation *)aLocation;

--- a/Source/OCMock/OCMMacroState.m
+++ b/Source/OCMock/OCMMacroState.m
@@ -66,9 +66,11 @@ static NSString *const OCMGlobalStateKey = @"OCMGlobalStateKey";
 }
 
 
-+ (void)beginRejectMacro
++ (void)beginRejectMacroAtLocation:(OCMLocation *)aLocation
 {
     OCMExpectationRecorder *recorder = [[[OCMExpectationRecorder alloc] init] autorelease];
+    [recorder setLocation:aLocation];
+    [recorder never];
     OCMMacroState *macroState = [[OCMMacroState alloc] initWithRecorder:recorder];
     [NSThread currentThread].threadDictionary[OCMGlobalStateKey] = macroState;
     [macroState release];

--- a/Source/OCMock/OCMock.h
+++ b/Source/OCMock/OCMock.h
@@ -82,7 +82,7 @@
 #define OCMReject(invocation) \
 ({ \
     _OCMSilenceWarnings( \
-        [OCMMacroState beginRejectMacro]; \
+        [OCMMacroState beginRejectMacroAtLocation:OCMMakeLocation(self, __FILE__, __LINE__)]; \
         OCMStubRecorder *recorder = nil; \
         @try{ \
             invocation; \

--- a/Source/OCMockTests/OCMockObjectMacroTests.m
+++ b/Source/OCMockTests/OCMockObjectMacroTests.m
@@ -284,10 +284,17 @@
 {
     id mock = OCMClassMock([TestClassForMacroTesting class]);
 
-    OCMReject([mock stringValue]);
+    OCMReject([mock stringValue]); const char *expectedFile = __FILE__; int expectedLine = __LINE__;
 
     XCTAssertNoThrow([mock verify], @"Should have accepted invocation rejected method not being invoked");
-    XCTAssertThrows([mock stringValue], @"Should have complained during rejected method being invoked");
+
+    shouldCaptureFailure = YES;
+    [mock stringValue];
+    shouldCaptureFailure = NO;
+    XCTAssertNotNil(reportedDescription, @"Should have recorded a failure with description.");
+    XCTAssertEqualObjects([NSString stringWithUTF8String:expectedFile], reportedFile, @"Should have reported correct file.");
+    XCTAssertEqual(expectedLine, (int)reportedLine, @"Should have reported correct line");
+
     XCTAssertThrows([mock verify], @"Should have complained about rejected method being invoked");
 }
 


### PR DESCRIPTION
Previously when messaging OCMReject only an exception was raised and the
failure was not associated with the line and file of declaration.