### PR TITLE
Replace asserts with exceptions.

### DIFF
--- a/Source/OCMock/OCClassMockObject.m
+++ b/Source/OCMock/OCClassMockObject.m
@@ -27,7 +27,10 @@
 
 - (id)initWithClass:(Class)aClass
 {
-    NSParameterAssert(aClass != nil);
+	if(aClass == nil)
+	{
+		[NSException raise:NSInvalidArgumentException format:@"Cannot initialize class mock with Nil class."];
+	}
 	[super init];
 	mockedClass = aClass;
     [self prepareClassForClassMethodMocking];

--- a/Source/OCMock/OCMMacroState.m
+++ b/Source/OCMock/OCMMacroState.m
@@ -140,7 +140,10 @@ static NSString *const OCMGlobalStateKey = @"OCMGlobalStateKey";
 - (void)dealloc
 {
     [recorder release];
-    NSAssert([NSThread currentThread].threadDictionary[OCMGlobalStateKey] != self, @"Unexpected dealloc while set as the global state");
+    if([NSThread currentThread].threadDictionary[OCMGlobalStateKey] == self)
+    {
+        [NSException raise:NSInternalInconsistencyException format:@"Unexpected dealloc while set as the global state"];
+    }
     [super dealloc];
 }
 

--- a/Source/OCMock/OCPartialMockObject.m
+++ b/Source/OCMock/OCPartialMockObject.m
@@ -30,7 +30,10 @@
 
 - (id)initWithObject:(NSObject *)anObject
 {
-    NSParameterAssert(anObject != nil);
+    if(anObject == nil)
+    {
+        [NSException raise:NSInvalidArgumentException format:@"Cannot initialize partial mock with nil object."];
+    }
     Class const class = [self classToSubclassForObject:anObject];
     [self assertClassIsSupported:class];
 	[super initWithClass:class];

--- a/Source/OCMock/OCProtocolMockObject.m
+++ b/Source/OCMock/OCProtocolMockObject.m
@@ -24,7 +24,10 @@
 
 - (id)initWithProtocol:(Protocol *)aProtocol
 {
-    NSParameterAssert(aProtocol != nil);
+	if(aProtocol == nil)
+	{
+		[NSException raise:NSInvalidArgumentException format:@"Cannot initialize protocol mock with Nil protocol."];
+	}
 	[super init];
 	mockedProtocol = aProtocol;
 	return self;


### PR DESCRIPTION
Replace uses of NSAssert with real exceptions because various builds turn off asserts using NS_BLOCK_ASSERTIONS, but we still want bad state to fail tests.