### PR TITLE
Disable invocation and arg actions for rejects.

### DIFF
--- a/Source/OCMock/OCMInvocationExpectation.m
+++ b/Source/OCMock/OCMInvocationExpectation.m
@@ -24,7 +24,14 @@
 {
     matchAndReject = flag;
     if(matchAndReject)
+    {
         isSatisfied = YES;
+        if([invocationActions count] > 0)
+        {
+            [NSException raise:NSInternalInconsistencyException format:@"%@: reject expectations can't have actions attached to them: %@",
+                [self description], invocationActions];
+        }
+    }
 }
 
 - (BOOL)isMatchAndReject
@@ -39,8 +46,6 @@
 
 - (void)handleInvocation:(NSInvocation *)anInvocation
 {
-   [super handleInvocation:anInvocation];
-
     if(matchAndReject)
     {
         isSatisfied = NO;
@@ -49,8 +54,18 @@
     }
     else
     {
+        [super handleInvocation:anInvocation];
         isSatisfied = YES;
     }
+}
+
+- (void)addInvocationAction:(id)anAction {
+    if(matchAndReject)
+    {
+        [NSException raise:NSInternalInconsistencyException format:@"%@: reject expectations can't have actions attached to them: %@",
+            [self description], anAction];
+    }
+    [super addInvocationAction:anAction];
 }
 
 @end

--- a/Source/OCMockTests/OCMockObjectMacroTests.m
+++ b/Source/OCMockTests/OCMockObjectMacroTests.m
@@ -291,6 +291,28 @@
     XCTAssertThrows([mock verify], @"Should have complained about rejected method being invoked");
 }
 
+- (void)testDontAllowAndBlocksOnRejects
+{  
+    NSNotification *notification = [NSNotification notificationWithName:@"Notification" object:nil];
+
+    // Version 3 syntax.
+    id mock = OCMClassMock([TestClassForMacroTesting class]);
+    XCTAssertThrows(OCMReject([mock stringValue]).andPost(notification));
+
+    // Version 2 syntax.
+    mock = OCMClassMock([TestClassForMacroTesting class]);
+    XCTAssertThrows([[[mock reject] andPost:notification] stringValue]);
+
+    // Mixes of version 2 and version 3 syntax.
+    mock = OCMClassMock([TestClassForMacroTesting class]);
+    XCTAssertThrows(OCMExpect([[[mock andPost:notification] never] stringValue]));
+
+    mock = OCMClassMock([TestClassForMacroTesting class]);
+    XCTAssertThrows(OCMExpect([[[mock never] andPost:notification] stringValue]));
+
+    mock = OCMClassMock([TestClassForMacroTesting class]);
+    XCTAssertThrows(OCMExpect([[mock never] stringValue]).andPost(notification));
+}
 
 - (void)testShouldNotReportErrorWhenMethodWasInvoked
 {


### PR DESCRIPTION
Throw an exception if invocationActions are added to a reject.

Refer to #434.