### PR TITLE
Exception when the (meta)class for a mock has been changed underneath it

### DIFF
--- a/Source/OCMock/OCClassMockObject.m
+++ b/Source/OCMock/OCClassMockObject.m
@@ -63,7 +63,7 @@
     }
     if(classCreatedForNewMetaClass != nil)
     {
-        objc_disposeClassPair(classCreatedForNewMetaClass);
+        OCMDisposeClassPair(classCreatedForNewMetaClass);
         classCreatedForNewMetaClass = nil;
     }
     [super stopMocking];

--- a/Source/OCMock/OCMFunctionsPrivate.h
+++ b/Source/OCMock/OCMFunctionsPrivate.h
@@ -33,6 +33,8 @@ BOOL OCMIsAppleBaseClass(Class cls);
 BOOL OCMIsApplePrivateMethod(Class cls, SEL sel);
 
 Class OCMCreateSubclass(Class cls, void *ref);
+BOOL OCMIsMockSubclass(Class cls);
+void OCMDisposeClassPair(Class cls);
 
 BOOL OCMIsAliasSelector(SEL selector);
 SEL OCMAliasForOriginalSelector(SEL selector);

--- a/Source/OCMock/OCPartialMockObject.m
+++ b/Source/OCMock/OCPartialMockObject.m
@@ -93,7 +93,7 @@
         object_setClass(realObject, [self mockedClass]);
         [realObject release];
         realObject = nil;
-        objc_disposeClassPair(partialMockClass);
+        OCMDisposeClassPair(partialMockClass);
     }
     [super stopMocking];
 }


### PR DESCRIPTION
In certain cases OCMock was deleting a class that it hadn't created, and then usually
causing a crash. It will now throw an exception when it determines that the class
has been changed.