### PR TITLE
Add support for classes blocking mocking.

### DIFF
--- a/Source/OCMock/OCClassMockObject.h
+++ b/Source/OCMock/OCClassMockObject.h
@@ -28,4 +28,13 @@
 - (Class)mockedClass;
 - (Class)mockObjectClass;  // since -class returns the mockedClass
 
+- (void)assertClassIsSupported:(Class)cls;
+
+@end
+
+@protocol OCClassMockBlocker
+// If a class does not support mocking, it can implement this method and return a reason.
+// Returning nil implies that mocking is supported, allowing you to optionally support mocking based
+// on runtime conditions.
++ (NSString *)reasonClassDoesNotSupportMocking;
 @end

--- a/Source/OCMock/OCClassMockObject.m
+++ b/Source/OCMock/OCClassMockObject.m
@@ -27,9 +27,7 @@
 
 - (id)initWithClass:(Class)aClass
 {
-	if(aClass == Nil)
-		[NSException raise:NSInvalidArgumentException format:@"Class cannot be Nil."];
-
+	[self assertClassIsSupported:aClass];
 	[super init];
 	mockedClass = aClass;
     [self prepareClassForClassMethodMocking];
@@ -52,6 +50,20 @@
 	return mockedClass;
 }
 
+- (void)assertClassIsSupported:(Class)cls {
+    if(cls == Nil)
+    {
+        [NSException raise:NSInvalidArgumentException format:@"Class cannot be Nil."];
+    }
+    if([cls respondsToSelector:@selector(reasonClassDoesNotSupportMocking)])
+    {
+        NSString *reason = [cls reasonClassDoesNotSupportMocking];
+        if(reason != nil)
+        {
+            [NSException raise:NSInvalidArgumentException format:@"Class `%@` does not support mocking: %@", cls, reason];
+        }
+    }
+}
 
 #pragma mark  Extending/overriding superclass behaviour
 

--- a/Source/OCMock/OCPartialMockObject.m
+++ b/Source/OCMock/OCPartialMockObject.m
@@ -30,11 +30,7 @@
 
 - (id)initWithObject:(NSObject *)anObject
 {
-    if(anObject == nil)
-        [NSException raise:NSInvalidArgumentException format:@"Object cannot be nil."];
-
     Class const class = [self classToSubclassForObject:anObject];
-    [self assertClassIsSupported:class];
 	[super initWithClass:class];
 	realObject = [anObject retain];
     [self prepareObjectForInstanceMethodMocking];
@@ -55,6 +51,7 @@
 
 - (void)assertClassIsSupported:(Class)class
 {
+    [super assertClassIsSupported:class];
     NSString *classname = NSStringFromClass(class);
     NSString *reason = nil;
     if([classname hasPrefix:@"__NSTagged"] || [classname hasPrefix:@"NSTagged"])

--- a/Source/OCMockTests/OCMockObjectTests.m
+++ b/Source/OCMockTests/OCMockObjectTests.m
@@ -192,6 +192,23 @@ TestOpaque myOpaque;
 
 @end
 
+@interface TestClassThatMayNotSupportMocking : NSObject
+@end
+
+@implementation TestClassThatMayNotSupportMocking
+static NSString *testClassThatMayNotSupportMockingReason = nil;
+
++ (void)setReason:(NSString *)reason
+{
+	testClassThatMayNotSupportMockingReason = reason;
+}
+
++ (NSString *)reasonClassDoesNotSupportMocking
+{
+	return testClassThatMayNotSupportMockingReason;
+}
+
+@end
 
 static NSString *TestNotification = @"TestNotification";
 
@@ -1100,6 +1117,13 @@ static NSString *TestNotification = @"TestNotification";
 
 }
 
+- (void)testClassThatDoesNotSupportMocking
+{
+    [TestClassThatMayNotSupportMocking setReason:@"Irreconcilable Differences"];
+    XCTAssertThrowsSpecificNamed(OCMClassMock([TestClassThatMayNotSupportMocking class]), NSException, NSInvalidArgumentException);
+    [TestClassThatMayNotSupportMocking setReason:nil];
+    XCTAssertNoThrow(OCMClassMock([TestClassThatMayNotSupportMocking class]));
+}
 
 @end
 


### PR DESCRIPTION
Certain classes should not be mocked. They may not be able to support being mocked
because of implementation details that conflict with how OCMock is implemented.
This allows library developers to prevent those classes from being mocked.