### PR TITLE
Swift Package Manager 

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -33,7 +33,7 @@ let package = Package(
                     "OCMockLib/OCMockLib-Prefix.pch",
                     "OCMockLibTests/OCMockLibTests-Prefix.pch",
                 ],
-                publicHeadersPath: "OCMock",
+                publicHeadersPath: "Public",
                 cSettings: [
                     .headerSearchPath("./"),
                     .unsafeFlags(["-fno-objc-arc"])

--- a/Package.swift
+++ b/Package.swift
@@ -33,7 +33,6 @@ let package = Package(
                     "OCMockLib/OCMockLib-Prefix.pch",
                     "OCMockLibTests/OCMockLibTests-Prefix.pch",
                 ],
-                sources: ["OCMock"],
                 publicHeadersPath: "OCMock",
                 cSettings: [
                     .headerSearchPath("./"),

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,48 @@
+// swift-tools-version:5.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "OCMock",
+    defaultLocalization: "en",
+    products: [
+        // Products define the executables and libraries produced by a package, and make them visible to other packages.
+        .library(
+            name: "OCMock",
+            targets: ["OCMock"]),
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        // .package(url: /* package url */, from: "1.0.0"),
+    ],
+    targets: [
+        .target(name: "OCMock",
+                dependencies: [],
+                path: "Source",
+                exclude: [
+                    "Carthage/",
+                    "Changes.txt",
+                    "OCMock/en.lproj/",
+                    "OCMock/OCMock-Info.plist",
+                    "OCMock/OCMock-Prefix.pch",
+                    "OCMockTests/",
+                    "Cartfile",
+                    "Cartfile.resolved",
+                    "OCMockLibTests/OCMockLibTests-Info.plist",
+                    "OCMockLib/OCMockLib-Prefix.pch",
+                    "OCMockLibTests/OCMockLibTests-Prefix.pch",
+                ],
+                sources: ["OCMock"],
+                publicHeadersPath: "OCMock",
+                cSettings: [
+                    .headerSearchPath("./"),
+                    .unsafeFlags(["-fno-objc-arc"])
+                ],
+                cxxSettings: nil,
+                swiftSettings: nil,
+                linkerSettings: nil
+        ),
+    ]
+)
+

--- a/Source/OCMock.xcodeproj/project.pbxproj
+++ b/Source/OCMock.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		030EF0B614632FD000B04273 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 030EF0B414632FD000B04273 /* InfoPlist.strings */; };
 		031E50581BB4A56300E257C3 /* OCMBoxedReturnValueProviderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 031E50571BB4A56300E257C3 /* OCMBoxedReturnValueProviderTests.m */; };
 		031E50591BB4A56300E257C3 /* OCMBoxedReturnValueProviderTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 031E50571BB4A56300E257C3 /* OCMBoxedReturnValueProviderTests.m */; };
 		0322DA65191188D100CACAF1 /* OCMockObjectVerifyAfterRunTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0322DA64191188D100CACAF1 /* OCMockObjectVerifyAfterRunTests.m */; };
@@ -461,7 +460,6 @@
 /* Begin PBXFileReference section */
 		030EF0A814632FD000B04273 /* OCMock.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = OCMock.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		030EF0B314632FD000B04273 /* OCMock-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "OCMock-Info.plist"; sourceTree = "<group>"; };
-		030EF0B514632FD000B04273 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		030EF0B714632FD000B04273 /* OCMock-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "OCMock-Prefix.pch"; sourceTree = "<group>"; };
 		030EF0B814632FD000B04273 /* OCMock.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OCMock.h; sourceTree = "<group>"; };
 		030EF0DC14632FF700B04273 /* libOCMock.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libOCMock.a; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -579,7 +577,6 @@
 		D31108B91828DB8700737925 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		D31108BD1828DB8700737925 /* OCMockLibTests-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "OCMockLibTests-Prefix.pch"; sourceTree = "<group>"; };
 		F0B950F11B0080BE00942C38 /* OCMock.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = OCMock.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		F0B950F41B0080BE00942C38 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = "OCMock iOS/Info.plist"; sourceTree = SOURCE_ROOT; };
 		F0B9510A1B0080D500942C38 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.3.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 /* End PBXFileReference section */
 
@@ -689,9 +686,7 @@
 		030EF0B214632FD000B04273 /* Supporting Files */ = {
 			isa = PBXGroup;
 			children = (
-				F0B950F41B0080BE00942C38 /* Info.plist */,
 				030EF0B314632FD000B04273 /* OCMock-Info.plist */,
-				030EF0B414632FD000B04273 /* InfoPlist.strings */,
 				030EF0B714632FD000B04273 /* OCMock-Prefix.pch */,
 			);
 			name = "Supporting Files";
@@ -1334,7 +1329,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				030EF0B614632FD000B04273 /* InfoPlist.strings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1680,14 +1674,6 @@
 /* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
-		030EF0B414632FD000B04273 /* InfoPlist.strings */ = {
-			isa = PBXVariantGroup;
-			children = (
-				030EF0B514632FD000B04273 /* en */,
-			);
-			name = InfoPlist.strings;
-			sourceTree = "<group>";
-		};
 		03565A3618F0566F003AE91E /* InfoPlist.strings */ = {
 			isa = PBXVariantGroup;
 			children = (

--- a/Source/OCMock/OCClassMockObject.h
+++ b/Source/OCMock/OCClassMockObject.h
@@ -14,7 +14,7 @@
  *  under the License.
  */
 
-#import <OCMock/OCMockObject.h>
+#import "OCMockObject.h"
 
 @interface OCClassMockObject : OCMockObject 
 {

--- a/Source/OCMock/OCMExpectationRecorder.h
+++ b/Source/OCMock/OCMExpectationRecorder.h
@@ -14,7 +14,7 @@
  *  under the License.
  */
 
-#import <OCMock/OCMock.h>
+#import "OCMock.h"
 
 @interface OCMExpectationRecorder : OCMStubRecorder
 

--- a/Source/OCMock/OCMStubRecorder.h
+++ b/Source/OCMock/OCMStubRecorder.h
@@ -14,8 +14,8 @@
  *  under the License.
  */
 
-#import <OCMock/OCMRecorder.h>
-#import <OCMock/OCMFunctions.h>
+#import "OCMRecorder.h"
+#import "OCMFunctions.h"
 #import <objc/runtime.h>
 
 @interface OCMStubRecorder : OCMRecorder

--- a/Source/OCMock/OCMock.h
+++ b/Source/OCMock/OCMock.h
@@ -14,17 +14,17 @@
  *  under the License.
  */
 
-#import <OCMock/OCMockObject.h>
-#import <OCMock/OCMRecorder.h>
-#import <OCMock/OCMVerifier.h>
-#import <OCMock/OCMStubRecorder.h>
-#import <OCMock/OCMConstraint.h>
-#import <OCMock/OCMArg.h>
-#import <OCMock/OCMLocation.h>
-#import <OCMock/OCMQuantifier.h>
-#import <OCMock/OCMMacroState.h>
-#import <OCMock/NSNotificationCenter+OCMAdditions.h>
-#import <OCMock/OCMFunctions.h>
+#import "OCMockObject.h"
+#import "OCMRecorder.h"
+#import "OCMVerifier.h"
+#import "OCMStubRecorder.h"
+#import "OCMConstraint.h"
+#import "OCMArg.h"
+#import "OCMLocation.h"
+#import "OCMQuantifier.h"
+#import "OCMMacroState.h"
+#import "NSNotificationCenter+OCMAdditions.h"
+#import "OCMFunctions.h"
 
 
 #ifdef OCM_DISABLE_SHORT_SYNTAX

--- a/Source/OCMock/OCProtocolMockObject.h
+++ b/Source/OCMock/OCProtocolMockObject.h
@@ -14,7 +14,7 @@
  *  under the License.
  */
 
-#import <OCMock/OCMockObject.h>
+#import "OCMockObject.h"
 
 @interface OCProtocolMockObject : OCMockObject 
 {

--- a/Source/OCMock/en.lproj/InfoPlist.strings
+++ b/Source/OCMock/en.lproj/InfoPlist.strings
@@ -1,2 +1,0 @@
-/* Localized versions of Info.plist keys */
-

--- a/Source/Public/NSNotificationCenter+OCMAdditions.h
+++ b/Source/Public/NSNotificationCenter+OCMAdditions.h
@@ -1,0 +1,1 @@
+../OCMock/NSNotificationCenter+OCMAdditions.h

--- a/Source/Public/OCMArg.h
+++ b/Source/Public/OCMArg.h
@@ -1,0 +1,1 @@
+../OCMock/OCMArg.h

--- a/Source/Public/OCMConstraint.h
+++ b/Source/Public/OCMConstraint.h
@@ -1,0 +1,1 @@
+../OCMock/OCMConstraint.h

--- a/Source/Public/OCMFunctions.h
+++ b/Source/Public/OCMFunctions.h
@@ -1,0 +1,1 @@
+../OCMock/OCMFunctions.h

--- a/Source/Public/OCMLocation.h
+++ b/Source/Public/OCMLocation.h
@@ -1,0 +1,1 @@
+../OCMock/OCMLocation.h

--- a/Source/Public/OCMMacroState.h
+++ b/Source/Public/OCMMacroState.h
@@ -1,0 +1,1 @@
+../OCMock/OCMMacroState.h

--- a/Source/Public/OCMQuantifier.h
+++ b/Source/Public/OCMQuantifier.h
@@ -1,0 +1,1 @@
+../OCMock/OCMQuantifier.h

--- a/Source/Public/OCMRecorder.h
+++ b/Source/Public/OCMRecorder.h
@@ -1,0 +1,1 @@
+../OCMock/OCMRecorder.h

--- a/Source/Public/OCMStubRecorder.h
+++ b/Source/Public/OCMStubRecorder.h
@@ -1,0 +1,1 @@
+../OCMock/OCMStubRecorder.h

--- a/Source/Public/OCMVerifier.h
+++ b/Source/Public/OCMVerifier.h
@@ -1,0 +1,1 @@
+../OCMock/OCMVerifier.h

--- a/Source/Public/OCMock.h
+++ b/Source/Public/OCMock.h
@@ -1,0 +1,1 @@
+../OCMock/OCMock.h

--- a/Source/Public/OCMockObject.h
+++ b/Source/Public/OCMockObject.h
@@ -1,0 +1,1 @@
+../OCMock/OCMockObject.h


### PR DESCRIPTION
Successor to https://github.com/erikdoe/ocmock/pull/402

- Updates to swift-tools-version:5.3
- Removes `Source/OCMock/en.lproj/InfoPlist.strings` which causes trouble for SPM and doesn't seem to be otherwise used
- Makes public headers findable from each other by using unqualified file name imports
- Sets up a `Public` folder for SPM public headers, since SPM cannot choose headers out of a larger directory.

The Public folder symbolic links to the public headers. Making a copy would be an alternative implementation that would allow other package manager implementations to be unchanged, but this seems to work and is easier to maintain.

Ideally all implementation would migrate to using a separate Public header folder implementation at some point.

Testing:

- I verified that this tests the current version of https://github.com/firebase/firebase-ios-sdk with Swift Package Manager.
- I've built and tested the targets I could find in https://github.com/erikdoe/ocmock/tree/master/Source/OCMock.xcodeproj

Fix #375