### PR TITLE
Add warning message regarding KVO notifications not being sent

### DIFF
--- a/Source/OCMock/OCPartialMockObject.m
+++ b/Source/OCMock/OCPartialMockObject.m
@@ -77,7 +77,11 @@
      */
 
     if([object observationInfo] != NULL)
-        return [object class];
+    {
+      NSLog(@"warning: The partial mock of `%@` will not receive the KVO notifications that it is currently registered for `%@`\n"
+            @"If you want this mock to receive KVO notifications, create the mock first, and then register the observations.", object, [object observationInfo]);
+      return [object class];
+    }
 
     return object_getClass(object);
 }


### PR DESCRIPTION
Creating a partial mock of an object that has KVO registrations was silently disabling the KVO notifications. This could lead to very confusing situations for the user. 

Emit a warning about creating partial mocks of objects with KVO registrations to try and make clear what the problem is.