### PR TITLE
Avoid problems when KVO is still registered on a mock object that is being stopped

### DIFF
--- a/Source/OCMock/OCPartialMockObject.h
+++ b/Source/OCMock/OCPartialMockObject.h
@@ -20,6 +20,7 @@
 {
 	NSObject		*realObject;
 	NSInvocation	*invocationFromMock;
+	Class classCreatedForPartialMock;
 }
 
 - (id)initWithObject:(NSObject *)anObject;

--- a/Source/OCMockTests/OCMockObjectPartialMocksTests.m
+++ b/Source/OCMockTests/OCMockObjectPartialMocksTests.m
@@ -772,18 +772,4 @@ static NSUInteger initializeCallCount = 0;
     }
 }
 
-- (void)testThrowsExceptionWhenAttemptingToTearDownWrongClass
-{
-    TestClassWithSimpleMethod *realObject = [[TestClassWithSimpleMethod alloc] init];
-    TestClassThatObservesFoo *observer = [[TestClassThatObservesFoo alloc] initWithObject:realObject];
-    id mock = [OCMockObject partialMockForObject:realObject];
-    [observer startObserving];
-    
-    // If we invoked stopObserving here, then stopMocking would work; but we want to test the error case.
-    XCTAssertThrowsSpecificNamed([mock stopMocking], NSException, NSInvalidArgumentException);
-    
-    // Must reset the object here to avoid any attempt to remove the observer, which would fail.
-    observer->observedObject = nil;
-}
-
 @end


### PR DESCRIPTION
The recommended pattern for KVO is now to let the runtime take care of unregistering
KVO observers at dealloc. This means that observers are often still registered on mocks
when they are being stopped. Both mocks and KVO change up the class tree and can easily
step on each other. We will do our best to clean up the classes we create, but "leaking"
a class is preferable to forcing users to deregister their KVO.