### PR TITLE
Allow users to determine if class is created by ocmock

### DIFF
--- a/Source/OCMock.xcodeproj/project.pbxproj
+++ b/Source/OCMock.xcodeproj/project.pbxproj
@@ -761,6 +761,7 @@
 				038599F623807B06002B3ABE /* OCMockObjectInternalTests.m */,
 				2FA2813F93050582D83E1499 /* OCMockObjectRuntimeTests.m */,
 				8BF73E52246CA75E00B9A52C /* OCMNoEscapeBlockTests.m */,
+				8BF6F13124CBCD3D005E6D93 /* OCMFunctionsTests.m */,
 				03B316271463350E0052CD09 /* OCMStubRecorderTests.m */,
 				037ECD5318FAD84100AF0E4C /* OCMInvocationMatcherTests.m */,
 				031E50571BB4A56300E257C3 /* OCMBoxedReturnValueProviderTests.m */,

--- a/Source/OCMock/OCMFunctions.h
+++ b/Source/OCMock/OCMFunctions.h
@@ -25,3 +25,8 @@
 
 
 OCMOCK_EXTERN BOOL OCMIsObjectType(const char *objCType);
+
+// Returns yes if cls is a subclass that was created by OCMock.
+// Note that cls should be from `objc_getClass(foo)`, as [foo class] called on a mock
+// will always return the class of the object being mocked, and not the mock class itself.
+OCMOCK_EXTERN BOOL OCMIsMockSubclass(Class cls);

--- a/Source/OCMock/OCMFunctionsPrivate.h
+++ b/Source/OCMock/OCMFunctionsPrivate.h
@@ -33,7 +33,7 @@ BOOL OCMIsAppleBaseClass(Class cls);
 BOOL OCMIsApplePrivateMethod(Class cls, SEL sel);
 
 Class OCMCreateSubclass(Class cls, void *ref);
-BOOL OCMIsMockSubclass(Class cls);
+BOOL OCMIsMockDirectSubclass(Class cls);
 void OCMDisposeSubclass(Class cls);
 
 BOOL OCMIsAliasSelector(SEL selector);

--- a/Source/OCMockTests/OCMFunctionsTests.m
+++ b/Source/OCMockTests/OCMFunctionsTests.m
@@ -15,6 +15,7 @@
  */
 
 #import <XCTest/XCTest.h>
+#import "OCMFunctions.h"
 #import "OCMFunctionsPrivate.h"
 
 @interface OCMFunctionsTests : XCTestCase
@@ -41,6 +42,17 @@
 - (void)testIsBlockReturnsTrueForBlock
 {
     XCTAssertTrue(OCMIsBlock(^{}));
+}
+
+- (void)testIsMockSubclass
+{
+  Class cls = OCMCreateSubclass([NSString class], "foo");
+  XCTAssertNotNil(cls);
+  XCTAssertTrue(OCMIsMockDirectSubclass(cls));
+  XCTAssertTrue(OCMIsMockSubclass(cls));
+  OCMDisposeSubclass(cls);
+  XCTAssertFalse(OCMIsMockSubclass([NSString class]));
+  XCTAssertFalse(OCMIsMockDirectSubclass([NSString class]));
 }
 
 @end


### PR DESCRIPTION
Some libraries that do their own swizzling for test purposes need to know if
a class is created by ocmock so they can deal with it specially.

This exposes a public function `OCMIsMockSubclass` that allows libraries to do this
without depending on "special" knowledge of class name strings.