### PR TITLE
Allow mocks to be created inside OCM Macro calls

### DIFF
--- a/Source/OCMock/OCMockObject.m
+++ b/Source/OCMock/OCMockObject.m
@@ -87,19 +87,18 @@
 
 - (instancetype)init
 {
+  if(stubs != nil)
+  {
     // check if we are called from inside a macro
     OCMRecorder *recorder = [[OCMMacroState globalState] recorder];
     if(recorder != nil)
     {
-        [recorder setMockObject:self];
+        // this is going to throw
         return (id)[recorder init];
     }
-
     // skip initialisation when init is called again, which can happen when stubbing alloc/init
-    if(stubs != nil)
-    {
-        return self;
-    }
+    return self;
+  }
 
     if([self class] == [OCMockObject class])
     {

--- a/Source/OCMockTests/OCMockObjectMacroTests.m
+++ b/Source/OCMockTests/OCMockObjectMacroTests.m
@@ -66,6 +66,27 @@
 
 @end
 
+@interface TestClassWithLazyMock : NSObject
+
+- (id)mock;
+
+@end
+
+@implementation TestClassWithLazyMock
+{
+    id _mock;
+}
+
+- (id)mock
+{
+    if(!_mock)
+    {
+        _mock = OCMClassMock([NSString class]);
+    }
+    return _mock;
+}
+
+@end
 
 // implemented in OCMockObjectClassMethodMockingTests
 
@@ -617,4 +638,10 @@
     }
 }
 
+- (void)testMockGeneratedLazily
+{
+    TestClassWithLazyMock *lazyMock = [[TestClassWithLazyMock alloc] init];
+    OCMStub([[lazyMock mock] lowercaseString]).andReturn(@"bar");
+    XCTAssertEqualObjects([[lazyMock mock] lowercaseString], @"bar");
+}
 @end


### PR DESCRIPTION
This allows a mock to be created inside an OCM Macro call while still preserving the case where we don't support mocking init.

Suggested fix for #449 