### PR TITLE
Remove unused code in retainObjectArgumentsExcludingObject

### DIFF
--- a/Source/OCMock/NSInvocation+OCMAdditions.m
+++ b/Source/OCMock/NSInvocation+OCMAdditions.m
@@ -122,22 +122,9 @@ static NSString *const OCMRetainedObjectArgumentsKey = @"OCMRetainedObjectArgume
     {
         id returnValue;
         [self getReturnValue:&returnValue];
-        if((returnValue != nil) && (returnValue != objectToExclude))
+        if(returnValue != nil)
         {
-            if(OCMIsBlockType(returnType))
-            {
-                // See above for an explanation
-                if(OCMIsNonEscapingBlock(returnValue) == NO)
-                {
-                    id blockReturnValue = [returnValue copy];
-                    [retainedArguments addObject:blockReturnValue];
-                    [blockReturnValue release];
-                }
-            }
-            else
-            {
-                [retainedArguments addObject:returnValue];
-            }
+            [NSException raise:NSInternalInconsistencyException format:@"Return values should always be nil from invocations."];
         }
     }
 


### PR DESCRIPTION
We should never have a return value set in `retainObjectArgumentsExcludingObject` so remove the untested code block that is there, and throw an exception if someehow we end up in this unexpected state.