### PR TITLE
Add support for debugging/logging

### DIFF
--- a/Source/OCMock/OCMStubRecorder.h
+++ b/Source/OCMock/OCMStubRecorder.h
@@ -60,6 +60,18 @@
 
 @property (nonatomic, readonly) OCMStubRecorder *(^ _ignoringNonObjectArgs)(void);
 
+// Break to the debugger when stub/expectation is called
+#define andDebugger() _andDo(^(NSInvocation *_invocation)             \
+{                                                                     \
+  __builtin_debugtrap();                                              \
+})                                                                    \
+
+// Log when stub/expectation is called.
+#define andLog(_format, ...) _andDo(^(NSInvocation *_invocation)      \
+{                                                                     \
+  NSLog(_format, ##__VA_ARGS__);                                      \
+})                                                                    \
+
 @end
 
 


### PR DESCRIPTION
Adds a `.andDebugger` and `.andLog` to stubs and expectations to make them easier to debug.