### PR TITLE
Add support for `[OCM anyPointer]` to invocation descriptions

### DIFF
--- a/Source/OCMock/NSInvocation+OCMAdditions.m
+++ b/Source/OCMock/NSInvocation+OCMAdditions.m
@@ -20,7 +20,7 @@
 #import "NSInvocation+OCMAdditions.h"
 #import "OCMFunctionsPrivate.h"
 #import "NSMethodSignature+OCMAdditions.h"
-
+#import "OCMArg.h"
 
 #if (TARGET_OS_OSX && (!defined(__MAC_10_10) || __MAC_OS_X_VERSION_MIN_REQUIRED < __MAC_10_10)) || \
     (TARGET_OS_IPHONE && (!defined(__IPHONE_8_0) || __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_8_0))
@@ -351,6 +351,11 @@ static NSString *const OCMRetainedObjectArgumentsKey = @"OCMRetainedObjectArgume
 	return [description autorelease];
 }
 
+- (NSString *)anyPointerDescription
+{
+	return @"<Any Pointer>";
+}
+
 - (NSString *)argumentDescriptionAtIndex:(NSInteger)argIndex
 {
 	const char *argType = OCMTypeWithoutQualifiers([[self methodSignature] getArgumentTypeAtIndex:(NSUInteger)argIndex]);
@@ -524,18 +529,32 @@ static NSString *const OCMRetainedObjectArgumentsKey = @"OCMRetainedObjectArgume
 	void *buffer;
 	
 	[self getArgument:&buffer atIndex:anInt];
-	return [NSString stringWithFormat:@"%p", buffer];
+	if(buffer == [OCMArg anyPointer])
+	{
+		return [self anyPointerDescription];
+	}
+	else
+	{
+		return [NSString stringWithFormat:@"%p", buffer];
+	}
 }
 
 - (NSString *)cStringDescriptionAtIndex:(NSInteger)anInt
 {
-	char buffer[104];
 	char *cStringPtr;
 	
 	[self getArgument:&cStringPtr atIndex:anInt];
-	strlcpy(buffer, cStringPtr, sizeof(buffer));
-	strlcpy(buffer + 100, "...", (sizeof(buffer) - 100));
-	return [NSString stringWithFormat:@"\"%s\"", buffer];
+	if(cStringPtr == [OCMArg anyPointer])
+	{
+		return [self anyPointerDescription];
+	}
+	else
+	{
+		char buffer[104];
+		strlcpy(buffer, cStringPtr, sizeof(buffer));
+		strlcpy(buffer + 100, "...", (sizeof(buffer) - 100));
+		return [NSString stringWithFormat:@"\"%s\"", buffer];
+	}
 }
 
 - (NSString *)selectorDescriptionAtIndex:(NSInteger)anInt

--- a/Source/OCMockTests/NSInvocationOCMAdditionsTests.m
+++ b/Source/OCMockTests/NSInvocationOCMAdditionsTests.m
@@ -16,7 +16,7 @@
 
 #import <XCTest/XCTest.h>
 #import "NSInvocation+OCMAdditions.h"
-
+#import "OCMArg.h"
 
 @implementation NSValue(OCMTestAdditions)
 
@@ -271,6 +271,15 @@
 	XCTAssertEqualObjects(expected, [invocation invocationDescription], @"");
 }
 
+- (void)testInvocationDescriptionWithCStringArgumentAnyPointer
+{
+	NSInvocation *invocation = [self invocationForClass:[NSString class] selector:@selector(initWithUTF8String:)];
+	const char *cString = [OCMArg anyPointer];
+	[invocation setArgument:&cString atIndex:2];
+
+	XCTAssertEqualObjects(@"initWithUTF8String:<Any Pointer>", [invocation invocationDescription]);
+}
+
 - (void)testInvocationDescriptionWithSelectorArgument
 {
 	NSInvocation *invocation = [self invocationForClass:[NSString class] selector:@selector(respondsToSelector:)];
@@ -296,6 +305,20 @@
 	XCTAssertTrue([invocationDescription rangeOfString:expected1].length > 0, @"");
 	XCTAssertTrue([invocationDescription rangeOfString:expected2].length > 0, @"");
 }
+
+- (void)testInvocationDescriptionWithPointerArgumentAnyPointer
+{
+	NSInvocation *invocation = [self invocationForClass:[NSData class] selector:@selector(initWithBytes:length:)];
+	const void *bytes = [OCMArg anyPointer];
+	NSUInteger length = 1500;
+	[invocation setArgument:&bytes atIndex:2];
+	[invocation setArgument:&length atIndex:3];
+
+	NSString *expected = [NSString stringWithFormat:@"initWithBytes:<Any Pointer> length:%lu", (unsigned long)length];
+	NSString *invocationDescription = [invocation invocationDescription];
+	XCTAssertEqualObjects(expected, invocationDescription);
+}
+
 
 - (void)testInvocationDescriptionWithNilArgument
 {


### PR DESCRIPTION
Invocation descriptions had trouble dealing with `[OCM anyPointer]`