### PR TITLE
Retain mocks to improve thread safety

### DIFF
--- a/Source/OCMock/OCClassMockObject.m
+++ b/Source/OCMock/OCClassMockObject.m
@@ -100,9 +100,12 @@
         return;
 
     /* if there is another mock for this exact class, stop it */
-    id otherMock = OCMGetAssociatedMockForClass(mockedClass, NO);
+    id otherMock = OCMRetainAssociatedMockForClass(mockedClass, NO);
     if(otherMock != nil)
+    {
         [otherMock stopMockingClassMethods];
+        [otherMock release];
+    }
 
     OCMSetAssociatedMockForClass(self, mockedClass);
 
@@ -166,7 +169,7 @@
 - (void)forwardInvocationForClassObject:(NSInvocation *)anInvocation
 {
 	// in here "self" is a reference to the real class, not the mock
-	OCClassMockObject *mock = OCMGetAssociatedMockForClass((Class) self, YES);
+    OCClassMockObject *mock = OCMRetainAssociatedMockForClass((Class) self, YES);
     if(mock == nil)
     {
         [NSException raise:NSInternalInconsistencyException format:@"No mock for class %@", NSStringFromClass((Class)self)];
@@ -176,6 +179,7 @@
         [anInvocation setSelector:OCMAliasForOriginalSelector([anInvocation selector])];
         [anInvocation invoke];
     }
+    [mock release];
 }
 
 - (void)initializeForClassObject

--- a/Source/OCMock/OCMFunctions.m
+++ b/Source/OCMock/OCMFunctions.m
@@ -402,16 +402,19 @@ void OCMSetAssociatedMockForClass(OCClassMockObject *mock, Class aClass)
     objc_setAssociatedObject(aClass, OCMClassMethodMockObjectKey, mock, OBJC_ASSOCIATION_ASSIGN);
 }
 
-OCClassMockObject *OCMGetAssociatedMockForClass(Class aClass, BOOL includeSuperclasses)
+OCClassMockObject *OCMRetainAssociatedMockForClass(Class aClass, BOOL includeSuperclasses)
 {
-    OCClassMockObject *mock = nil;
     do
     {
-        mock = objc_getAssociatedObject(aClass, OCMClassMethodMockObjectKey);
+        OCClassMockObject *mock = objc_getAssociatedObject(aClass, OCMClassMethodMockObjectKey);
+        if(mock != nil)
+        {
+            return [mock retain];
+        }
         aClass = class_getSuperclass(aClass);
     }
-    while((mock == nil) && (aClass != nil) && includeSuperclasses);
-    return mock;
+    while((aClass != nil) && includeSuperclasses);
+    return nil;
 }
 
 static NSString *const OCMPartialMockObjectKey = @"OCMPartialMockObjectKey";
@@ -423,9 +426,10 @@ void OCMSetAssociatedMockForObject(OCClassMockObject *mock, id anObject)
     objc_setAssociatedObject(anObject, OCMPartialMockObjectKey, mock, OBJC_ASSOCIATION_ASSIGN);
 }
 
-OCPartialMockObject *OCMGetAssociatedMockForObject(id anObject)
+OCPartialMockObject *OCMRetainAssociatedMockForObject(id anObject)
 {
-    return objc_getAssociatedObject(anObject, OCMPartialMockObjectKey);
+    OCPartialMockObject *object = objc_getAssociatedObject(anObject, OCMPartialMockObjectKey);
+    return [object retain];
 }
 
 

--- a/Source/OCMock/OCMFunctionsPrivate.h
+++ b/Source/OCMock/OCMFunctionsPrivate.h
@@ -41,10 +41,10 @@ SEL OCMAliasForOriginalSelector(SEL selector);
 SEL OCMOriginalSelectorForAlias(SEL selector);
 
 void OCMSetAssociatedMockForClass(OCClassMockObject *mock, Class aClass);
-OCClassMockObject *OCMGetAssociatedMockForClass(Class aClass, BOOL includeSuperclasses);
+OCClassMockObject *OCMRetainAssociatedMockForClass(Class aClass, BOOL includeSuperclasses) NS_RETURNS_RETAINED;
 
 void OCMSetAssociatedMockForObject(OCClassMockObject *mock, id anObject);
-OCPartialMockObject *OCMGetAssociatedMockForObject(id anObject);
+OCPartialMockObject *OCMRetainAssociatedMockForObject(id anObject) NS_RETURNS_RETAINED;
 
 void OCMReportFailure(OCMLocation *loc, NSString *description);
 


### PR DESCRIPTION
Mock objects are currently only retained by the thread that created them.
This patch retains the mock by the thread calling it for the lifetime of the call.
Previously Thread A that created the mock could kill it off while Thread B that was
calling the mock was using it.
This greatly improves the thread safety of using mocks (although it's still risky).