### PR TITLE
Retain returnValues

### DIFF
--- a/Source/OCMock/OCMNonRetainingObjectReturnValueProvider.m
+++ b/Source/OCMock/OCMNonRetainingObjectReturnValueProvider.m
@@ -46,6 +46,13 @@
         [returnValue retain];
         [[anInvocation target] release];
     }
+    else
+    {
+        // Return with an autorelease to avoid race condition between when returnValue is
+        // being returned, and when returnValue is received where the mock is torn down
+        // and returnValue is released.
+        returnValue = [[returnValue retain] autorelease];
+    }
     [anInvocation setReturnValue:&returnValue];
 }
 @end


### PR DESCRIPTION
Retain the returnValues so they aren't released between the time they are returned
and the time they are either retained by the caller, or in the case of non ARC calling
code possibly not retained at all because the receiver was expecting a retained value.