### PR TITLE
Retain objects passed as block arguments.

### DIFF
--- a/Source/OCMock.xcodeproj/project.pbxproj
+++ b/Source/OCMock.xcodeproj/project.pbxproj
@@ -283,6 +283,8 @@
 		8B11D4B82448E2F400247BE2 /* OCMCPlusPlus98Tests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 8B11D4B62448E2E900247BE2 /* OCMCPlusPlus98Tests.mm */; settings = {COMPILER_FLAGS = "-std=gnu++98"; }; };
 		8B11D4BA2448E53600247BE2 /* OCMCPlusPlus11Tests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 8B11D4B92448E53600247BE2 /* OCMCPlusPlus11Tests.mm */; settings = {COMPILER_FLAGS = "-std=gnu++11"; }; };
 		8B11D4BB2448E53600247BE2 /* OCMCPlusPlus11Tests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 8B11D4B92448E53600247BE2 /* OCMCPlusPlus11Tests.mm */; settings = {COMPILER_FLAGS = "-std=gnu++11"; }; };
+		8B3786A824E5BD5600FD1B5B /* OCMFunctionsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B3786A724E5BD5600FD1B5B /* OCMFunctionsTests.m */; };
+		8B3786A924E5BD6400FD1B5B /* OCMFunctionsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B3786A724E5BD5600FD1B5B /* OCMFunctionsTests.m */; };
 		8BF73E53246CA75E00B9A52C /* OCMNoEscapeBlockTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BF73E52246CA75E00B9A52C /* OCMNoEscapeBlockTests.m */; settings = {COMPILER_FLAGS = "-Xclang -fexperimental-optimized-noescape"; }; };
 		8BF73E54246CA75E00B9A52C /* OCMNoEscapeBlockTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BF73E52246CA75E00B9A52C /* OCMNoEscapeBlockTests.m */; settings = {COMPILER_FLAGS = "-Xclang -fexperimental-optimized-noescape"; }; };
 		8DE97C5522B43EE60098C63F /* OCMockObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 03B3159E146333BF0052CD09 /* OCMockObject.m */; };
@@ -577,6 +579,7 @@
 		817EB1621BD765130047E85A /* OCMock.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = OCMock.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8B11D4B62448E2E900247BE2 /* OCMCPlusPlus98Tests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = OCMCPlusPlus98Tests.mm; sourceTree = "<group>"; };
 		8B11D4B92448E53600247BE2 /* OCMCPlusPlus11Tests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = OCMCPlusPlus11Tests.mm; sourceTree = "<group>"; };
+		8B3786A724E5BD5600FD1B5B /* OCMFunctionsTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OCMFunctionsTests.m; sourceTree = "<group>"; };
 		8BF73E52246CA75E00B9A52C /* OCMNoEscapeBlockTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OCMNoEscapeBlockTests.m; sourceTree = "<group>"; };
 		8DE97CA022B43EE60098C63F /* OCMock.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = OCMock.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A02926811CA0725A00594AAF /* TestObjects.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = TestObjects.xcdatamodel; sourceTree = "<group>"; };
@@ -758,6 +761,7 @@
 				031E50571BB4A56300E257C3 /* OCMBoxedReturnValueProviderTests.m */,
 				03B316211463350E0052CD09 /* OCMConstraintTests.m */,
 				8B11D4B62448E2E900247BE2 /* OCMCPlusPlus98Tests.mm */,
+				8B3786A724E5BD5600FD1B5B /* OCMFunctionsTests.m */,
 				8B11D4B92448E53600247BE2 /* OCMCPlusPlus11Tests.mm */,
 				2FA28EDBF243639C57F88A1B /* OCMArgTests.m */,
 				036865631D3571A8005E6BEE /* OCMQuantifierTests.m */,
@@ -1494,6 +1498,7 @@
 			files = (
 				037ECD5418FAD84100AF0E4C /* OCMInvocationMatcherTests.m in Sources */,
 				03565A4418F05721003AE91E /* OCMockObjectProtocolMocksTests.m in Sources */,
+				8B3786A824E5BD5600FD1B5B /* OCMFunctionsTests.m in Sources */,
 				03565A4B18F05721003AE91E /* NSInvocationOCMAdditionsTests.m in Sources */,
 				03565A4618F05721003AE91E /* OCMockObjectHamcrestTests.m in Sources */,
 				3CFBDD771BB3DB200050D9C5 /* TestClassWithCustomReferenceCounting.m in Sources */,
@@ -1609,6 +1614,7 @@
 			files = (
 				3C76716C1BB3EBC500FDC9F4 /* TestClassWithCustomReferenceCounting.m in Sources */,
 				031E50591BB4A56300E257C3 /* OCMBoxedReturnValueProviderTests.m in Sources */,
+				8B3786A924E5BD6400FD1B5B /* OCMFunctionsTests.m in Sources */,
 				03C9CA1E18F05A84006DF94D /* OCMArgTests.m in Sources */,
 				036865651D3571A8005E6BEE /* OCMQuantifierTests.m in Sources */,
 				0322DA66191188D100CACAF1 /* OCMockObjectVerifyAfterRunTests.m in Sources */,

--- a/Source/OCMock/NSInvocation+OCMAdditions.m
+++ b/Source/OCMock/NSInvocation+OCMAdditions.m
@@ -90,17 +90,27 @@ static NSString *const OCMRetainedObjectArgumentsKey = @"OCMRetainedObjectArgume
             {
                 if(OCMIsBlockType(argumentType))
                 {
-                    // Block types need to be copied because they could be stack blocks.
-                    // However, non-escaping blocks have a lifetime that is stack-based and they
-                    // treat copy/release as a no-op. For details see:
-                    // https://reviews.llvm.org/rGdbfa453e4138bb977644929c69d1c71e5e8b4bee
-                    // If we keep a reference to a non-escaping block in retainedArguments, it
-                    // will end up as dangling pointer, resulting in a crash later.
-                    if(OCMIsNonEscapingBlock(argument) == NO)
+                    if (OCMIsBlock(argument))
                     {
-                        id blockArgument = [argument copy];
-                        [retainedArguments addObject:blockArgument];
-                        [blockArgument release];
+                      // Block types need to be copied because they could be stack blocks.
+                      // However, non-escaping blocks have a lifetime that is stack-based and they
+                      // treat copy/release as a no-op. For details see:
+                      // https://reviews.llvm.org/rGdbfa453e4138bb977644929c69d1c71e5e8b4bee
+                      // If we keep a reference to a non-escaping block in retainedArguments, it
+                      // will end up as dangling pointer, resulting in a crash later.
+                      if(OCMIsNonEscapingBlock(argument) == NO)
+                      {
+                          id blockArgument = [argument copy];
+                          [retainedArguments addObject:blockArgument];
+                          [blockArgument release];
+                      }
+                    }
+                    else
+                    {
+                      // The type is a block type, but the value being passed in is not a block.
+                      // This happens in the case of an OCMArgAction or an OCMConstraint. In this
+                      // case we do need to retain.
+                      [retainedArguments addObject:argument];
                     }
                 }
                 else if(OCMIsClassType(argumentType) && object_isClass(argument))

--- a/Source/OCMock/OCMFunctions.m
+++ b/Source/OCMock/OCMFunctions.m
@@ -328,11 +328,26 @@ BOOL OCMIsApplePrivateMethod(Class cls, SEL sel)
             ([selName hasPrefix:@"_"] || [selName hasSuffix:@"_"]);
 }
 
+BOOL OCMIsBlock(id potentialBlock)
+{
+    static Class blockClass;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^
+    {
+        blockClass = [^{} class];
+        Class nsObjectClass = [NSObject class];
+        while([blockClass superclass] != nsObjectClass)
+        {
+            blockClass = [blockClass superclass];
+        }
+    });
+    return [potentialBlock isKindOfClass:blockClass];
+}
 
 BOOL OCMIsNonEscapingBlock(id block)
 {
     struct OCMBlockDef *blockRef = (__bridge struct OCMBlockDef *)block;
-    return (blockRef->flags & OCMBlockIsNoEscape) != 0;
+    return OCMIsBlock(block) && (blockRef->flags & OCMBlockIsNoEscape) != 0;
 }
 
 

--- a/Source/OCMock/OCMFunctionsPrivate.h
+++ b/Source/OCMock/OCMFunctionsPrivate.h
@@ -48,6 +48,7 @@ OCPartialMockObject *OCMGetAssociatedMockForObject(id anObject);
 
 void OCMReportFailure(OCMLocation *loc, NSString *description);
 
+BOOL OCMIsBlock(id potentialBlock);
 BOOL OCMIsNonEscapingBlock(id block);
 
 

--- a/Source/OCMockTests/OCMFunctionsTests.m
+++ b/Source/OCMockTests/OCMFunctionsTests.m
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2020 Erik Doernenburg and contributors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use these files except in compliance with the License. You may obtain
+ *  a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations
+ *  under the License.
+ */
+
+#import <XCTest/XCTest.h>
+#import "OCMFunctionsPrivate.h"
+
+@interface OCMFunctionsTests : XCTestCase
+@end
+
+
+@implementation OCMFunctionsTests
+
+- (void)testOCMIsBlock
+{
+  XCTAssertFalse(OCMIsBlock([NSString class]));
+  XCTAssertFalse(OCMIsBlock(@""));
+  XCTAssertFalse(OCMIsBlock([NSString stringWithFormat:@"%d", 42]));
+  XCTAssertFalse(OCMIsBlock(nil));
+  XCTAssertTrue(OCMIsBlock(^{}));
+}
+
+@end

--- a/Source/OCMockTests/OCMockObjectTests.m
+++ b/Source/OCMockTests/OCMockObjectTests.m
@@ -878,6 +878,24 @@ static NSString *TestNotification = @"TestNotification";
     XCTAssertEqual(firstParam, mockProtocol, @"Param does not match");
 }
 
+- (void)testBlockConstraintRetainedByStub
+{
+    __block BOOL wasCalled = NO;
+    id mock = OCMClassMock([NSString class]);
+    @autoreleasepool 
+    {
+        // The autorelease pool makes sure that the OCMArg is retained by the stub.
+        // If this test fails it will likely be due to a crash.
+        OCMStub([mock enumerateLinesUsingBlock:([OCMArg invokeBlockWithArgs:@"Happy", [OCMArg defaultValue], nil])]);
+    }
+    [mock enumerateLinesUsingBlock:^(NSString * _Nonnull line, BOOL * _Nonnull stop) 
+    {
+        wasCalled = YES;
+    }];
+    XCTAssertTrue(wasCalled);
+}
+
+
 #pragma mark    accepting expected methods
 
 - (void)testAcceptsExpectedMethod


### PR DESCRIPTION
In some cases OCMArgActions and/or OCMConstraints are passed as "blocks".
We need to retain those actions/blocks in our invocation matchers.

Fix for #458.