### PR TITLE
Deprecate OCMObserverMockObjects

### DIFF
--- a/Source/OCMock/NSNotificationCenter+OCMAdditions.m
+++ b/Source/OCMock/NSNotificationCenter+OCMAdditions.m
@@ -20,10 +20,13 @@
 
 @implementation NSNotificationCenter(OCMAdditions)
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (void)addMockObserver:(OCObserverMockObject *)notificationObserver name:(NSString *)notificationName object:(id)notificationSender
 {
     [notificationObserver autoRemoveFromCenter:self];
 	[self addObserver:notificationObserver selector:@selector(handleNotification:) name:notificationName object:notificationSender];
 }
+#pragma clang diagnostic pop
 
 @end

--- a/Source/OCMock/OCMockObject.h
+++ b/Source/OCMock/OCMockObject.h
@@ -41,7 +41,7 @@
 + (id)niceMockForClass:(Class)aClass;
 + (id)niceMockForProtocol:(Protocol *)aProtocol;
 
-+ (id)observerMock;
++ (id)observerMock __deprecated_msg("Please use `XCTNSNotificationExpectation` instead.");
 
 - (instancetype)init;
 

--- a/Source/OCMock/OCObserverMockObject.h
+++ b/Source/OCMock/OCObserverMockObject.h
@@ -19,6 +19,7 @@
 @class OCMLocation;
 
 
+__deprecated_msg("Please use `XCTNSNotificationExpectation` instead.")
 @interface OCObserverMockObject : NSObject 
 {
 	BOOL		    expectationOrderMatters;

--- a/Source/OCMock/OCObserverMockObject.m
+++ b/Source/OCMock/OCObserverMockObject.m
@@ -20,8 +20,10 @@
 #import "OCMObserverRecorder.h"
 #import "OCMFunctionsPrivate.h"
 
-
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 @implementation OCObserverMockObject
+#pragma clang diagnostic pop
 
 #pragma mark  Initialisers, description, accessors, etc.
 

--- a/Source/OCMockTests/OCMockObjectMacroTests.m
+++ b/Source/OCMockTests/OCMockObjectMacroTests.m
@@ -226,7 +226,10 @@
 
     NSNotification *n = [NSNotification notificationWithName:@"TestNotification" object:nil];
 
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     id observer = OCMObserverMock();
+    #pragma clang diagnostic pop
     [[NSNotificationCenter defaultCenter] addMockObserver:observer name:[n name] object:nil];
     OCMExpect([observer notificationWithName:[n name] object:[OCMArg any]]);
 
@@ -239,7 +242,10 @@
 
 - (void)testNotificationObservingWithUserInfo
 {
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     id observer = OCMObserverMock();
+    #pragma clang diagnostic pop
     [[NSNotificationCenter defaultCenter] addMockObserver:observer name:@"TestNotificationWithInfo" object:nil];
     OCMExpect([observer notificationWithName:@"TestNotificationWithInfo" object:[OCMArg any] userInfo:[OCMArg any]]);
 

--- a/Source/OCMockTests/OCObserverMockObjectTests.m
+++ b/Source/OCMockTests/OCObserverMockObjectTests.m
@@ -35,7 +35,10 @@ static NSString *TestNotificationOne = @"TestNotificationOne";
 - (void)setUp
 {
 	center = [[NSNotificationCenter alloc] init];
-	mock = [OCMockObject observerMock]; 
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+	mock = [OCMockObject observerMock];
+  #pragma clang diagnostic pop
 }
 
 - (void)testAcceptsExpectedNotification


### PR DESCRIPTION
AFAICT XCTNSNotificationExpectations can fulfill all the requirements of
OCMObserverMockObjects, so let's set ourselves up so we can remove the cruft.

Fix for #463 463