### PR TITLE
Fix a stack overflow within -[OCMBoxedReturnValueProvider handleInvocation:]

### DIFF
--- a/Source/OCMock/OCMBoxedReturnValueProvider.m
+++ b/Source/OCMock/OCMBoxedReturnValueProvider.m
@@ -23,14 +23,16 @@
 
 - (void)handleInvocation:(NSInvocation *)anInvocation
 {
-	const char *returnType = [[anInvocation methodSignature] methodReturnType];
-    NSUInteger returnTypeSize = [[anInvocation methodSignature] methodReturnLength];
-    char valueBuffer[returnTypeSize];
+    NSUInteger valueSize = 0;
     NSValue *returnValueAsNSValue = (NSValue *)returnValue;
+    NSGetSizeAndAlignment([returnValueAsNSValue objCType], &valueSize, NULL);
+    char valueBuffer[valueSize];
     [returnValueAsNSValue getValue:valueBuffer];
 
+    const char *returnType = [[anInvocation methodSignature] methodReturnType];
+
     if([self isMethodReturnType:returnType compatibleWithValueType:[returnValueAsNSValue objCType]
-                value:valueBuffer valueSize:returnTypeSize])
+                value:valueBuffer valueSize:valueSize])
     {
         [anInvocation setReturnValue:valueBuffer];
     }


### PR DESCRIPTION
The code was using the method signature's return type to determine how large a stack buffer should be used for retrieving the overridden return value. This was problematic as the overridden return value may not be of the same type as the method signature's return type. It may be an unrelated type, in the case where `-handleInvocation:` would go on to throw an exception, or it may be a related type of a different size. This comes up when dealing with methods of a `BOOL` return type but overriding the return value with an integer literal (`0`/`1`) or C11 boolean constant (`true`/`false`) which are of type `int` and so require more than a single byte to store.

To address this we now use a size derived from the overridden return value's Objective-C type encoding to determine how
large a buffer is required.