### PR TITLE
Block direct instantiation of OCMockObject

### DIFF
--- a/Source/OCMock/OCMockObject.m
+++ b/Source/OCMock/OCMockObject.m
@@ -101,6 +101,11 @@
         return self;
     }
 
+  if([self class] == [OCMockObject class])
+  {
+    [NSException raise:NSInternalInconsistencyException format:@"Error: OCMockObject should not be instantiated directly. Please use an appropriate subclass."];
+  }
+
 	// no [super init], we're inheriting from NSProxy
 	expectationOrderMatters = NO;
 	stubs = [[NSMutableArray alloc] init];

--- a/Source/OCMockTests/OCMockObjectTests.m
+++ b/Source/OCMockTests/OCMockObjectTests.m
@@ -1099,6 +1099,11 @@ static NSString *TestNotification = @"TestNotification";
 
 }
 
+- (void)testDirectInstantiationOfOCMockObject
+{
+    XCTAssertThrows([[OCMockObject alloc] init]);
+}
+
 
 @end
 


### PR DESCRIPTION
Prevents users from accidentally instantiating an OCMockObject.