### PR TITLE
Enforce that you cannot partial mock a proxy.

### DIFF
--- a/Source/OCMock/OCPartialMockObject.m
+++ b/Source/OCMock/OCPartialMockObject.m
@@ -31,6 +31,8 @@
 {
     if(anObject == nil)
         [NSException raise:NSInvalidArgumentException format:@"Object cannot be nil."];
+    if([anObject isProxy])
+        [NSException raise:NSInvalidArgumentException format:@"OCMock does not support partially mocking subclasses of NSProxy."];
     Class const class = [self classToSubclassForObject:anObject];
     [super initWithClass:class];
     realObject = [anObject retain];

--- a/Source/OCMockTests/OCMockObjectPartialMocksTests.m
+++ b/Source/OCMockTests/OCMockObjectPartialMocksTests.m
@@ -301,6 +301,11 @@ static NSUInteger initializeCallCount = 0;
     XCTAssertEqualObjects(@"stubbed", [realObject categoryMethod], @"Should have stubbed NSObject's method");
 }
 
+- (void)testMocksAProxy
+{
+    id proxy = [NSProxy alloc];
+    XCTAssertThrows([OCMockObject partialMockForObject:proxy]);
+}
 
 #pragma mark Tests for remembering invocations for later verification
 

--- a/Source/OCMockTests/OCMockObjectTests.m
+++ b/Source/OCMockTests/OCMockObjectTests.m
@@ -214,6 +214,18 @@ static NSString *testClassThatMayNotSupportMockingReason = nil;
 
 @end
 
+@interface TestClassThatInheritsFromNSProxy : NSProxy
+@end
+
+@implementation TestClassThatInheritsFromNSProxy
+
+- (NSString *)foo
+{
+    return @"foo";
+}
+
+@end
+
 static NSString *TestNotification = @"TestNotification";
 
 
@@ -1157,5 +1169,11 @@ static NSString *TestNotification = @"TestNotification";
     XCTAssertThrows([[OCMockObject alloc] init]);
 }
 
+- (void)testSupportsNSProxyBaseClasses
+{
+  id mock = OCMClassMock([TestClassThatInheritsFromNSProxy class]);
+  OCMStub([mock foo]).andReturn(@"bar");
+  XCTAssertEqualObjects([mock foo], @"bar");
+}
 
 @end


### PR DESCRIPTION
If you manage to pass a proxy into OCMPartialMock it crashes quite quickly, so let's just prevent it from happening at all.

Also test that you can class mock a proxy.