### PR TITLE
Fix up usage of NSGetSizeAndAlignment

### DIFF
--- a/Source/OCMock/NSInvocation+OCMAdditions.m
+++ b/Source/OCMock/NSInvocation+OCMAdditions.m
@@ -140,7 +140,7 @@ static NSString *const OCMRetainedObjectArgumentsKey = @"OCMRetainedObjectArgume
         else if(OCMNumberTypeForObjCType(typeEncoding))
         {
             NSUInteger argSize;
-            NSGetSizeAndAlignment(typeEncoding, NULL, &argSize);
+            NSGetSizeAndAlignment(typeEncoding, &argSize, NULL);
             void *argBuffer = calloc(1, argSize);
             [self setArgument:argBuffer atIndex:idx];
             free(argBuffer);


### PR DESCRIPTION
NSGetSizeAndAlignment is horribly documented IMHO. The alignp argument is the alignment of the type, not the aligned size of the type. On a 64 bit system this just "happens" to work for many types that aren't structs.