### PR TITLE
Check expected file path as a suffix in OCMockObjectMacroTests

### DIFF
--- a/Source/OCMockTests/OCMockObjectMacroTests.m
+++ b/Source/OCMockTests/OCMockObjectMacroTests.m
@@ -134,7 +134,7 @@
     shouldCaptureFailure = NO;
 
     XCTAssertNotNil(reportedDescription, @"Should have recorded a failure with description.");
-    XCTAssertEqualObjects([NSString stringWithUTF8String:expectedFile], reportedFile, @"Should have reported correct file.");
+    XCTAssertTrue([reportedFile hasSuffix:[NSString stringWithUTF8String:expectedFile]], @"Should have reported correct file.");
     XCTAssertEqual(expectedLine, (int)reportedLine, @"Should have reported correct line");
 }
 
@@ -158,7 +158,7 @@
     shouldCaptureFailure = NO;
 
     XCTAssertTrue([reportedDescription rangeOfString:@"ignored"].location != NSNotFound, @"Should have reported ignored exceptions.");
-    XCTAssertEqualObjects([NSString stringWithUTF8String:expectedFile], reportedFile, @"Should have reported correct file.");
+    XCTAssertTrue([reportedFile hasSuffix:[NSString stringWithUTF8String:expectedFile]], @"Should have reported correct file.");
     XCTAssertEqual(expectedLine, (int)reportedLine, @"Should have reported correct line");
 }
 
@@ -173,7 +173,7 @@
     shouldCaptureFailure = NO;
 
     XCTAssertNotNil(reportedDescription, @"Should have recorded a failure with description.");
-    XCTAssertEqualObjects([NSString stringWithUTF8String:expectedFile], reportedFile, @"Should have reported correct file.");
+    XCTAssertTrue([reportedFile hasSuffix:[NSString stringWithUTF8String:expectedFile]], @"Should have reported correct file.");
     XCTAssertEqual(expectedLine, (int)reportedLine, @"Should have reported correct line");
 }
 
@@ -380,7 +380,7 @@
     shouldCaptureFailure = NO;
 
     XCTAssertNotNil(reportedDescription, @"Should have recorded a failure with description.");
-    XCTAssertEqualObjects([NSString stringWithUTF8String:expectedFile], reportedFile, @"Should have reported correct file.");
+    XCTAssertTrue([reportedFile hasSuffix:[NSString stringWithUTF8String:expectedFile]], @"Should have reported correct file.");
     XCTAssertEqual(expectedLine, (int)reportedLine, @"Should have reported correct line");
 }
 


### PR DESCRIPTION
The `expectedFile` is actually a suffix of `reportedFile` on my local run. The test started failing with the equality check.
Switch to check if it's a suffix resolves the issue.