### PR TITLE
Remove unnecessary shadow variable

### DIFF
--- a/Source/OCMockTests/OCMockObjectTests.m
+++ b/Source/OCMockTests/OCMockObjectTests.m
@@ -903,7 +903,6 @@ static NSString *TestNotification = @"TestNotification";
 - (void)testBlockConstraintRetainedByStub
 {
     __block BOOL wasCalled = NO;
-    id mock = OCMClassMock([NSString class]);
     @autoreleasepool
     {
         // The autorelease pool makes sure that the OCMArg is retained by the stub.


### PR DESCRIPTION
This shadow variable `mock` is from `testBlockConstraintRetainedByStub`.
The `mock` is already defined as a private variable in the `@implementation` section.
With `-Wshadow` and `-Werror` this became an error so we should fix this.