### PR TITLE
All subclasses of OCMockObject should get `stopMocking` called on them in dealloc

### DIFF
--- a/Source/OCMock/OCClassMockObject.m
+++ b/Source/OCMock/OCClassMockObject.m
@@ -39,12 +39,6 @@
     return self;
 }
 
-- (void)dealloc
-{
-    [self stopMocking];
-    [super dealloc];
-}
-
 - (NSString *)description
 {
     return [NSString stringWithFormat:@"OCClassMockObject(%@)", NSStringFromClass(mockedClass)];

--- a/Source/OCMock/OCMockObject.m
+++ b/Source/OCMock/OCMockObject.m
@@ -117,10 +117,10 @@
 
 - (void)dealloc
 {
+    [self stopMocking];
     [stubs release];
     [expectations release];
     [exceptions release];
-    [invocations release];
     [super dealloc];
 }
 


### PR DESCRIPTION
This seems like a reasonable expectation of the API and in our case enables code that
depends on stopMocking to function with OCProtocolMockObjects.