### PR TITLE
Exclude missing "Carthage" directory from SwiftPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,6 @@ let package = Package(
             dependencies: [],
             path: "Source",
             exclude: [
-                "Carthage/",
                 "Changes.txt",
                 "OCMock/OCMock-Info.plist",
                 "OCMock/OCMock-Prefix.pch",


### PR DESCRIPTION
This directory doesn't exist and now shows a warning in Xcode 13 beta 1.

Will be testing this shortly with the Firebase distribution to ensure it works as expected, I'll confirm in a comment when it's good to go and still works within Xcode 12.