### PR TITLE
Fix up crash when calling object_getClass on non object.

### DIFF
--- a/Source/OCMock/OCMArg.m
+++ b/Source/OCMock/OCMArg.m
@@ -35,7 +35,7 @@
 
 + (id __autoreleasing *)anyObjectRef
 {
-    return (id *)0x01234567;
+    return (id *)[self anyPointer];
 }
 
 + (SEL)anySelector
@@ -127,9 +127,9 @@
     if(type[0] == '^')
     {
         void *pointer = [value pointerValue];
-        if(pointer == (void *)0x01234567)
+        if(pointer == [self anyPointer])
             return [OCMArg any];
-        if((pointer != NULL) && (object_getClass((id)pointer) == [OCMPassByRefSetter class]))
+        if((pointer != NULL) && [OCMPassByRefSetter ptrIsPassByRefSetter:pointer])
             return (id)pointer;
     }
     else if(type[0] == ':')

--- a/Source/OCMock/OCMPassByRefSetter.h
+++ b/Source/OCMock/OCMPassByRefSetter.h
@@ -23,4 +23,7 @@
 
 - (id)initWithValue:(id)value;
 
+// Returns YES if ptr is actually a OCMPassByRefSetter
++ (BOOL)ptrIsPassByRefSetter:(void*)ptr;
+
 @end


### PR DESCRIPTION
This fixes up a crash that was found in Chrome when running on an iOS 15 device.
It did not show up on the simulator.

https://chromium-review.googlesource.com/c/chromium/src/+/3011651

Calling `object_getClass` on something that isn't an object is at best undefined
behavior.