### PR TITLE
Added a 'pod_target_xcconfig' declaration in the 'OCMock.podspec' file to change the 'ENABLE_BITCODE' build setting value to 'NO'

### DIFF
--- a/OCMock.podspec
+++ b/OCMock.podspec
@@ -29,6 +29,8 @@ Pod::Spec.new do |s|
   s.ios.framework             = 'XCTest'
   s.tvos.framework            = 'XCTest'
 
+  s.pod_target_xcconfig       = { 'ENABLE_BITCODE' => 'NO' }
+
   s.public_header_files       = ["OCMock.h", "OCMockObject.h", "OCMArg.h", "OCMConstraint.h", 
                                  "OCMLocation.h", "OCMMacroState.h", "OCMRecorder.h", 
                                  "OCMStubRecorder.h", "NSNotificationCenter+OCMAdditions.h", 


### PR DESCRIPTION
Without this, the 'ENABLE_BITCODE' build setting for the 'OCMock' target in the 'Pods' project resolves to 'Yes'. This then causes any testing target which links to 'OCMock' to fail to build when built to run on a real (non-simulator) device. The build error in such a scenario is the following:

```
'/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework/XCTest' does not contain bitcode. You must rebuild it with bitcode enabled (Xcode setting ENABLE_BITCODE), obtain an updated library from the vendor, or disable bitcode for this target. file '/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework/XCTest' for architecture arm64
```

See [issue #46](https://github.com/nschum/SwiftHamcrest/issues/46) in the [SwiftHamcrest](https://github.com/nschum/SwiftHamcrest) GitHub repository which displayed the same error and was resolved in the same manner as the change in this pull request.