### PR TITLE
Fix invalid exclude warning

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,6 @@ let package = Package(
             dependencies: [],
             path: "Source",
             exclude: [
-                "Carthage/",
                 "Changes.txt",
                 "OCMock/OCMock-Info.plist",
                 "OCMock/OCMock-Prefix.pch",


### PR DESCRIPTION
This PR removes an invalid exclude in the OCMock `Package.swift`. This eliminates the attached warning from Xcode  when using OCMock from Swift Package Manager.

<img width="445" alt="Screen Shot 2021-09-15 at 12 22 22 PM" src="https://user-images.githubusercontent.com/36927374/133474486-f90dacaa-cb74-44b7-a053-e04a13ede4d4.png">

cc: @paulb777 
