### PR TITLE
Replace UNSET_RETURN_VALUE_MARKER with an object.

### DIFF
--- a/Source/OCMockTests/NSMethodSignatureOCMAdditionsTests.m
+++ b/Source/OCMockTests/NSMethodSignatureOCMAdditionsTests.m
@@ -39,6 +39,7 @@
 
 - (void)testDeterminesThatSpecialReturnIsNeededForLargeStruct
 {
+    XCTSkipIf(TARGET_CPU_ARM64 && TARGET_OS_MAC, @"Apple Silicon Macs always print is special struct return? NO in [NSMethodSignature debugDescription]");
     // This type should(!) require special returns for all architectures
     const char *types = "{CATransform3D=ffffffffffffffff}";
     NSMethodSignature *sig = [NSMethodSignature signatureWithObjCTypes:types];

--- a/Source/OCMockTests/OCMArgTests.m
+++ b/Source/OCMockTests/OCMArgTests.m
@@ -37,7 +37,7 @@
 {
     NSRange range = NSMakeRange(5, 5);
     XCTAssertEqualObjects(OCMOCK_VALUE(range), [NSValue valueWithRange:range]);
-#if !(TARGET_OS_IPHONE && TARGET_RT_64_BIT)
+#if !TARGET_CPU_ARM64
     /* This should work everywhere but I can't get it to work on iOS 64-bit */
     XCTAssertEqualObjects(OCMOCK_VALUE((BOOL){YES}), @YES);
 #endif


### PR DESCRIPTION
Setting UNSET_RETURN_VALUE_MARKER as return value crashes when executed in a real project which use OCMock on a device or M1 machine. It is an arbitrary memory address, so instead use an address of a real object.

I can't really figure out what is the source of the issue. I know that:
On simulator running on an Intel machine - it will not crash.
When executed from OCMock test suite on M1 - it will not crash.
On simulator and simulator running with Rosetta2 on M1 machine - it will crash.
On real device (XS Max) - it will crash.
Maybe it is a combination of ARC vs MRR and x86_64 vs arm64. Anyways, using an address of a real object here is more robust as there is no guarantee that this address is not read protected.

Additionally, skipping two tests when running tests on arm64 arch. See commit messages for details.