### PR TITLE
Fix Xcode 14.3 build issue

### DIFF
--- a/OCMock.podspec
+++ b/OCMock.podspec
@@ -21,7 +21,7 @@ Pod::Spec.new do |s|
   s.source_files              = "Source/OCMock/*.{h,m}"
 
   s.requires_arc              = false
-  s.osx.deployment_target     = '10.10'
+  s.osx.deployment_target     = '10.11'
   s.ios.deployment_target     = '9.0'
   s.tvos.deployment_target    = '9.0'
   s.watchos.deployment_target = '4.0'


### PR DESCRIPTION
Xcode 14.3 does not support building for a minimum macOS target of 10.10.

More context at https://stackoverflow.com/questions/75574268/missing-file-libarclite-iphoneos-a-xcode-14-3