### PR TITLE
Add visionos platform support to podspec

### DIFF
--- a/OCMock.podspec
+++ b/OCMock.podspec
@@ -25,6 +25,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target     = '9.0'
   s.tvos.deployment_target    = '9.0'
   s.watchos.deployment_target = '4.0'
+  s.visionos.deployment_target = '1.0'
   s.osx.framework             = 'XCTest'
   s.ios.framework             = 'XCTest'
   s.tvos.framework            = 'XCTest'


### PR DESCRIPTION
With the release of [CocoaPods v1.13.0](https://github.com/CocoaPods/CocoaPods/releases/tag/1.13.0), visionOS support was introduced.