### PR TITLE
Add the ability to ignore selectors on mocks to handle methods with variadic arguments.

### DIFF
--- a/Source/OCMock/OCClassMockObject.h
+++ b/Source/OCMock/OCClassMockObject.h
@@ -22,8 +22,8 @@
     Class originalMetaClass;
     Class classCreatedForNewMetaClass;
 }
-
-- (id)initWithClass:(Class)aClass;
+- (id)initForMockingClass:(Class)aClass;
+- (id)initForMockingInstancesOfClass:(Class)aClass;
 
 - (Class)mockedClass;
 - (Class)mockObjectClass; // since -class returns the mockedClass

--- a/Source/OCMock/OCClassMockObject.m
+++ b/Source/OCMock/OCClassMockObject.m
@@ -166,6 +166,12 @@
 
 - (void)setupForwarderForClassMethodSelector:(SEL)selector
 {
+    for(Class aClass in [OCMockObject classesIgnoringMockedSelector:selector])
+    {
+        if([mockedClass isKindOfClass:aClass])
+            return;
+    }
+    
     SEL aliasSelector = OCMAliasForOriginalSelector(selector);
     if(class_getClassMethod(mockedClass, aliasSelector) != NULL)
         return;

--- a/Source/OCMock/OCMArg.h
+++ b/Source/OCMock/OCMArg.h
@@ -36,6 +36,7 @@
 
 + (id *)setTo:(id)value;
 + (void *)setToValue:(NSValue *)value;
++ (id *)setToResultOfBlock:(id(^)(void))block;
 + (id)invokeBlock;
 + (id)invokeBlockWithArgs:(id)first, ... NS_REQUIRES_NIL_TERMINATION;
 

--- a/Source/OCMock/OCMArg.m
+++ b/Source/OCMock/OCMArg.m
@@ -87,6 +87,10 @@
     return (id *)[[[OCMPassByRefSetter alloc] initWithValue:value] autorelease];
 }
 
++ (id *)setToResultOfBlock:(id(^)(void))block{
+    return (id *)[[[OCMPassByRefSetter alloc] initWithBlock:block] autorelease];
+}
+
 + (void *)setToValue:(NSValue *)value
 {
     return (id *)[[[OCMPassByRefSetter alloc] initWithValue:value] autorelease];

--- a/Source/OCMock/OCMPassByRefSetter.h
+++ b/Source/OCMock/OCMPassByRefSetter.h
@@ -19,9 +19,11 @@
 @interface OCMPassByRefSetter : OCMArgAction
 {
     id value;
+    id(^block)(void);
 }
 
 - (id)initWithValue:(id)value;
+- (id)initWithBlock:(id(^)(void))block;
 
 + (BOOL)isPassByRefSetterInstance:(void *)ptr;
 

--- a/Source/OCMock/OCMockMacros.h
+++ b/Source/OCMock/OCMockMacros.h
@@ -155,3 +155,5 @@
     macro \
     _Pragma("clang diagnostic pop") \
 })
+
+#define OCMIgnore(class,selector) do { [OCMockObject  ignoreMethod:selector forClass:class];} while(0);

--- a/Source/OCMock/OCMockObject.h
+++ b/Source/OCMock/OCMockObject.h
@@ -43,6 +43,9 @@
 
 + (id)observerMock __deprecated_msg("Please use XCTNSNotificationExpectation instead.");
 
++ (NSArray <Class> *)classesIgnoringMockedSelector:(SEL)aSelector;
++ (void)ignoreMethod:(SEL) selector forClass:(Class) aClass;
+
 - (instancetype)init;
 
 - (void)setExpectationOrderMatters:(BOOL)flag;

--- a/Source/OCMock/OCMockObject.h
+++ b/Source/OCMock/OCMockObject.h
@@ -65,6 +65,7 @@
 // internal use only
 
 - (void)addStub:(OCMInvocationStub *)aStub;
+- (void)removeStubsForSelector:(SEL)selector;
 - (void)addExpectation:(OCMInvocationExpectation *)anExpectation;
 - (void)addInvocation:(NSInvocation *)anInvocation;
 

--- a/Source/OCMock/OCMockObject.m
+++ b/Source/OCMock/OCMockObject.m
@@ -45,7 +45,7 @@
 
 + (id)mockForClass:(Class)aClass
 {
-    return [[[OCClassMockObject alloc] initWithClass:aClass] autorelease];
+    return [[[OCClassMockObject alloc] initForMockingClass:aClass] autorelease];
 }
 
 + (id)mockForProtocol:(Protocol *)aProtocol

--- a/Source/OCMock/OCMockObject.m
+++ b/Source/OCMock/OCMockObject.m
@@ -213,7 +213,7 @@ NSDictionary <NSString*,NSSet <Class> *>  * _static_ignoredBySelectorName;
 - (void)removeStubsForSelector:(SEL)selector{
     @synchronized (stubs) {
         int s = stubs.count;
-        while (--s){
+        while (s--){
             OCMInvocationStub * stub = stubs[s];
             if ([stub isKindOfClass:OCMInvocationStub.class]){
                 if (stub.recordedInvocation.selector == selector){

--- a/Source/OCMock/OCMockObject.m
+++ b/Source/OCMock/OCMockObject.m
@@ -210,6 +210,19 @@ NSDictionary <NSString*,NSSet <Class> *>  * _static_ignoredBySelectorName;
     expectationOrderMatters = flag;
 }
 
+- (void)removeStubsForSelector:(SEL)selector{
+    @synchronized (stubs) {
+        int s = stubs.count;
+        while (--s){
+            OCMInvocationStub * stub = stubs[s];
+            if ([stub isKindOfClass:OCMInvocationStub.class]){
+                if (stub.recordedInvocation.selector == selector){
+                    [stubs removeObjectAtIndex:s];
+                }
+            }
+        }
+    }
+}
 - (void)stopMocking
 {
     // invocations can contain objects that clients expect to be deallocated by now,

--- a/Source/OCMock/OCPartialMockObject.m
+++ b/Source/OCMock/OCPartialMockObject.m
@@ -199,6 +199,12 @@
 
 - (void)setupForwarderForSelector:(SEL)sel
 {
+    
+    for(Class aClass in [OCMockObject classesIgnoringMockedSelector:sel])
+    {
+        if([realObject isKindOfClass:aClass])
+            return;
+    }
     SEL aliasSelector = OCMAliasForOriginalSelector(sel);
     if(class_getInstanceMethod(object_getClass(realObject), aliasSelector) != NULL)
         return;
@@ -232,6 +238,14 @@
 - (id)forwardingTargetForSelectorForRealObject:(SEL)sel
 {
     // in here "self" is a reference to the real object, not the mock
+    
+    for(Class aClass in [OCMockObject classesIgnoringMockedSelector:sel])
+    {
+        if([self isKindOfClass:aClass])
+            return self;
+    }
+    
+    
     OCPartialMockObject *mock = OCMGetAssociatedMockForObject(self);
     if(mock == nil)
         [NSException raise:NSInternalInconsistencyException format:@"No partial mock for object %p", self];

--- a/Source/OCMock/OCPartialMockObject.m
+++ b/Source/OCMock/OCPartialMockObject.m
@@ -34,7 +34,7 @@
     if([anObject isProxy])
         [NSException raise:NSInvalidArgumentException format:@"OCMock does not support partially mocking subclasses of NSProxy."];
     Class const class = [self classToSubclassForObject:anObject];
-    [super initWithClass:class];
+    [super initForMockingInstancesOfClass:class];
     realObject = [anObject retain];
     [self prepareObjectForInstanceMethodMocking];
     return self;

--- a/Source/OCMockTests/OCMockObjectClassMethodMockingTests.m
+++ b/Source/OCMockTests/OCMockObjectClassMethodMockingTests.m
@@ -220,7 +220,7 @@ static NSUInteger initializeCallCount = 0;
 
 - (void)testRevertsAllStubbedMethodsOnDealloc
 {
-    id mock = [[OCClassMockObject alloc] initWithClass:[TestClassWithClassMethods class]];
+    id mock = [[OCClassMockObject alloc] initForMockingClass:[TestClassWithClassMethods class]];
 
     [[[[mock stub] classMethod] andReturn:@"mocked-foo"] foo];
     [[[[mock stub] classMethod] andReturn:@"mocked-bar"] bar];
@@ -236,7 +236,7 @@ static NSUInteger initializeCallCount = 0;
 
 - (void)testRevertsAllStubbedMethodsOnPartialMockDealloc
 {
-    id mock = [[OCPartialMockObject alloc] initWithClass:[TestClassWithClassMethods class]];
+    id mock = [[OCPartialMockObject alloc] initForMockingClass:[TestClassWithClassMethods class]];
 
     [[[[mock stub] classMethod] andReturn:@"mocked-foo"] foo];
     [[[[mock stub] classMethod] andReturn:@"mocked-bar"] bar];
@@ -252,10 +252,10 @@ static NSUInteger initializeCallCount = 0;
 
 - (void)testSecondClassMockDeactivatesFirst
 {
-    id mock1 = [[OCClassMockObject alloc] initWithClass:[TestClassWithClassMethods class]];
+    id mock1 = [[OCClassMockObject alloc] initForMockingClass:[TestClassWithClassMethods class]];
     [[[mock1 stub] andReturn:@"mocked-foo-1"] foo];
 
-    id mock2 = [[OCClassMockObject alloc] initWithClass:[TestClassWithClassMethods class]];
+    id mock2 = [[OCClassMockObject alloc] initForMockingClass:[TestClassWithClassMethods class]];
     XCTAssertEqualObjects(@"Foo-ClassMethod", [TestClassWithClassMethods foo]);
 
     [mock2 stopMocking];
@@ -264,7 +264,7 @@ static NSUInteger initializeCallCount = 0;
 
 - (void)testStopMockingDisposesMetaClass
 {
-    id mock = [[OCClassMockObject alloc] initWithClass:[TestClassWithClassMethods class]];
+    id mock = [[OCClassMockObject alloc] initForMockingClass:[TestClassWithClassMethods class]];
 
     char *createdSubclassName = strdup(object_getClassName([TestClassWithClassMethods class]));
     XCTAssertNotNil(objc_lookUpClass(createdSubclassName));
@@ -276,11 +276,11 @@ static NSUInteger initializeCallCount = 0;
 
 - (void)testSecondClassMockDisposesFirstMetaClass
 {
-    id mock1 = [[OCClassMockObject alloc] initWithClass:[TestClassWithClassMethods class]];
+    id mock1 = [[OCClassMockObject alloc] initForMockingClass:[TestClassWithClassMethods class]];
     char *createdSubclassName1 = strdup(object_getClassName([TestClassWithClassMethods class]));
     XCTAssertNotNil(objc_lookUpClass(createdSubclassName1));
 
-    id mock2 = [[OCClassMockObject alloc] initWithClass:[TestClassWithClassMethods class]];
+    id mock2 = [[OCClassMockObject alloc] initForMockingClass:[TestClassWithClassMethods class]];
     char *createdSubclassName2 = strdup(object_getClassName([TestClassWithClassMethods class]));
     XCTAssertNotNil(objc_lookUpClass(createdSubclassName2));
 


### PR DESCRIPTION
OC Mock does not handle mocked classes that have methods with variadic arguments.   
Eg `-(void)log:(NSString*)format, ....;`

When theses methods are called on mocked objects, the variadic arguments are not included in the NSInvocation that is created in the message forwarding. As a result the process will likely crash.

I needed a mechanism to tell OCMock to ignore specific selectors when setting up A mock.  To do this I added a registry of selectors and classes that should not use the mock forwarding process.  

The methods that determine whether a selector is handled, forwarded, and the target of the selector consults the registry and will pass the selector to the real Object when it is to be ignored.  

Example Usage:

OCMIgnore([MYClass class],@selector(methodWithVariadicArgs:));

