### PR TITLE
Add visionOS support back to podspec

### DIFF
--- a/OCMock.podspec
+++ b/OCMock.podspec
@@ -25,6 +25,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target     = '12.0'
   s.tvos.deployment_target    = '12.0'
   s.watchos.deployment_target = '7.0'
+  s.visionos.deployment_target = '1.0'
   s.osx.framework             = 'XCTest'
   s.ios.framework             = 'XCTest'
   s.tvos.framework            = 'XCTest'

--- a/OCMock.podspec
+++ b/OCMock.podspec
@@ -30,6 +30,7 @@ Pod::Spec.new do |s|
   s.ios.framework             = 'XCTest'
   s.tvos.framework            = 'XCTest'
   s.watchos.framework         = 'XCTest'
+  s.visionos.framework        = 'XCTest'
 
   s.pod_target_xcconfig       = { 'ENABLE_BITCODE' => 'NO' }
 


### PR DESCRIPTION
Cocoapods fully supports visionOS (which seemed to be why #532 had to revert the support), so let's add this back.