### PR TITLE
Address static analyzer warning in OCPartialMockObject (Issue #543)

### DIFF
--- a/Source/OCMock/OCPartialMockObject.m
+++ b/Source/OCMock/OCPartialMockObject.m
@@ -206,6 +206,9 @@
     Method originalMethod = class_getInstanceMethod(mockedClass, sel);
     /* Might be NULL if the selector is forwarded to another class */
     IMP originalIMP = (originalMethod != NULL) ? method_getImplementation(originalMethod) : NULL;
+    if(originalIMP == NULL)
+        return;
+
     const char *types = (originalMethod != NULL) ? method_getTypeEncoding(originalMethod) : NULL;
     // TODO: check the fallback implementation is actually sufficient
     if(types == NULL)


### PR DESCRIPTION
* Issue #543 about potential nil passed to class_addMethod()

OCPartialMockObject#setupForwarderForSelector
* Modified to just return if there is no existing implementation for the method