### PR TITLE
Allow to mock multiple protocol in a single object

### DIFF
--- a/Source/OCMock/OCMockMacros.h
+++ b/Source/OCMock/OCMockMacros.h
@@ -27,7 +27,11 @@
 
 #define OCMProtocolMock(protocol) [OCMockObject niceMockForProtocol:protocol]
 
+#define OCMProtocolsMock(protocols) [OCMockObject niceMockForProtocols:protocols]
+
 #define OCMStrictProtocolMock(protocol) [OCMockObject mockForProtocol:protocol]
+
+#define OCMStrictProtocolsMock(protocols) [OCMockObject mockForProtocol:protocols]
 
 #define OCMPartialMock(obj) [OCMockObject partialMockForObject:obj]
 

--- a/Source/OCMock/OCMockObject.h
+++ b/Source/OCMock/OCMockObject.h
@@ -36,10 +36,12 @@
 
 + (id)mockForClass:(Class)aClass;
 + (id)mockForProtocol:(Protocol *)aProtocol;
++ (id)mockForProtocols:(NSArray<Protocol *>*)aProtocols;
 + (id)partialMockForObject:(NSObject *)anObject;
 
 + (id)niceMockForClass:(Class)aClass;
 + (id)niceMockForProtocol:(Protocol *)aProtocol;
++ (id)niceMockForProtocols:(NSArray<Protocol *> *)aProtocols;
 
 + (id)observerMock __deprecated_msg("Please use XCTNSNotificationExpectation instead.");
 

--- a/Source/OCMock/OCMockObject.m
+++ b/Source/OCMock/OCMockObject.m
@@ -53,6 +53,11 @@
     return [[[OCProtocolMockObject alloc] initWithProtocol:aProtocol] autorelease];
 }
 
++ (id)mockForProtocols:(NSArray<Protocol *> *)aProtocol
+{
+    return [[[OCProtocolMockObject alloc] initWithProtocols:aProtocol] autorelease];
+}
+
 + (id)partialMockForObject:(NSObject *)anObject
 {
     return [[[OCPartialMockObject alloc] initWithObject:anObject] autorelease];
@@ -67,6 +72,11 @@
 + (id)niceMockForProtocol:(Protocol *)aProtocol
 {
     return [self _makeNice:[self mockForProtocol:aProtocol]];
+}
+
++ (id)niceMockForProtocols:(NSArray<Protocol *> *)aProtocols
+{
+    return [self _makeNice:[self mockForProtocols:aProtocols]];
 }
 
 

--- a/Source/OCMock/OCProtocolMockObject.h
+++ b/Source/OCMock/OCProtocolMockObject.h
@@ -18,9 +18,10 @@
 
 @interface OCProtocolMockObject : OCMockObject
 {
-    Protocol *mockedProtocol;
+  NSArray<Protocol *> *mockedProtocols;
 }
 
 - (id)initWithProtocol:(Protocol *)aProtocol;
+- (id)initWithProtocols:(NSArray<Protocol *> *)aProtocols;
 
 @end


### PR DESCRIPTION
An Objective-C object can naturally implements an arbitrary number of protocol. I ended up in a case where I had to modify my code, because an object was expected to implement two protocols and OCMock does not allow it. I’d love to see this code merged so that it can.

I also edited the code for nice mocks in order for the API to be consistent. I don’t actually need it.

It should be noted that the description is not changed in the case where there is a single protocol mocked.