### PR TITLE
[iOS]Ensures all expectations are followed by a verify

### DIFF
--- a/Source/OCMock/OCMockObject.m
+++ b/Source/OCMock/OCMockObject.m
@@ -30,7 +30,9 @@
 #import "OCProtocolMockObject.h"
 
 
-@implementation OCMockObject
+@implementation OCMockObject {
+  BOOL _mustBeVerified;
+}
 
 #pragma mark Class initialisation
 
@@ -119,6 +121,11 @@
 
 - (void)dealloc
 {
+    if(_mustBeVerified){
+        NSString *description = [NSString stringWithFormat:@"%@: was deallocated without being verified",
+                                          [self description]];
+        OCMReportFailure(nil, description);
+    }
     [stubs release];
     [expectations release];
     [exceptions release];
@@ -153,6 +160,7 @@
 
 - (void)addExpectation:(OCMInvocationExpectation *)anExpectation
 {
+    _mustBeVerified = YES;
     @synchronized(expectations)
     {
         [expectations addObject:anExpectation];
@@ -228,6 +236,7 @@
 
 - (id)verifyAtLocation:(OCMLocation *)location
 {
+    _mustBeVerified = NO;
     NSMutableArray *unsatisfiedExpectations = [NSMutableArray array];
     @synchronized(expectations)
     {


### PR DESCRIPTION
The error message if it is not the case state that the expect can be replaced by stub if we actually don’t care about verifying. Chrome code ended up with dozens and dozens of tests that failed to verify because the author and the reviewer forgot to add this last check. I believe that having a way to require all verify to be called would improve the usability of this class in tests.

I understand that you may not be able to merge it as-is, at upgrading would break the test flow of many of your users. Instead, I suspect that you’ll want a way to enable this feature progressively, at user request. I’m willing to work with you to ensure that we can merge this feature if you accept it.

For our usage in chromium, I expect the simpler way to deal with this feature is to have some #DEFINE macro. If a build-time constant is defined, we enable the feature, other wise it’s disabled.

It would also be possible to have a static boolean that default to false, and that the test should switch to true to enable the safety feature.